### PR TITLE
Initial commit for logger

### DIFF
--- a/cmd/ion/main.go
+++ b/cmd/ion/main.go
@@ -43,10 +43,10 @@ func main() {
 	ctxSignal := logFactory.BuildLoggerForCtx(ctx, "signal")
 	ctxSfu := logFactory.BuildLoggerForCtx(ctx, "sfu")
 	// Signal not printed due to error level
-	sigLogger := logFactory.FromContext(ctxSignal)
+	sigLogger := logFactory.FromCtx(ctxSignal)
 	sigLogger.InfoContext(ctxSignal, "Start signaling")
 	// Sfu printed due to debug level
-	sfuLogger := logFactory.FromContext(ctxSfu)
+	sfuLogger := logFactory.FromCtx(ctxSfu)
 	sfuLogger.InfoContext(ctxSfu, "Starting SFU")
 
 	fmt.Println(ctxSignal)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	go.uber.org/zap v1.27.0
+	go.uber.org/zap/exp v0.3.0
 )
 
 require (
@@ -19,6 +21,7 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,14 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+go.uber.org/zap/exp v0.3.0 h1:6JYzdifzYkGmTdRR59oYH+Ng7k49H9qVpWwNSsGJj3U=
+go.uber.org/zap/exp v0.3.0/go.mod h1:5I384qq7XGxYyByIhHm6jg5CHkGY0nsTfbDLgDDlgJQ=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,11 +13,15 @@ import (
 	"github.com/spf13/viper"
 )
 
-type LogFormat string
-type WriterType string
+type (
+	LogFormat  string
+	WriterType string
+)
 
-var ErrInvalidWriterType = errors.New("invalid writer type")
-var ErrInvalidFormatType = errors.New("invalid format type")
+var (
+	ErrInvalidWriterType = errors.New("invalid writer type")
+	ErrInvalidFormatType = errors.New("invalid format type")
+)
 
 const (
 	LogFormatText LogFormat  = "text"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -13,10 +14,16 @@ import (
 )
 
 type LogFormat string
+type WriterType string
+
+var ErrInvalidWriterType = errors.New("invalid writer type")
+var ErrInvalidFormatType = errors.New("invalid format type")
 
 const (
-	LogFormatText LogFormat = "text"
-	LogFormatJSON LogFormat = "json"
+	LogFormatText LogFormat  = "text"
+	LogFormatJSON LogFormat  = "json"
+	WriterStderr  WriterType = "stderr"
+	WriterStdout  WriterType = "stdout"
 )
 
 const (

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -124,7 +124,7 @@ func (f *LoggerFactory) BuildLoggerForCtx(ctx context.Context, scope string) con
 	return WithContext(ctx, slog.New(h))
 }
 
-// FromCtx returns the logger stored in ctx or the factory root.
+// FromCtx returns the logger stored in ctx or the factory root logger.
 func (f *LoggerFactory) FromCtx(ctx context.Context) *slog.Logger {
 	if lg := retriveLoggerfromCtx(ctx); lg != nil {
 		return lg
@@ -134,13 +134,13 @@ func (f *LoggerFactory) FromCtx(ctx context.Context) *slog.Logger {
 }
 
 // RetriveLoggerfromCtx retrieves the logger associated with ctx
-// or returns slog.Default().
+// or returns nil.
 func retriveLoggerfromCtx(ctx context.Context) *slog.Logger {
 	if l, ok := ctx.Value(ctxKey{}).(*slog.Logger); ok && l != nil {
 		return l
 	}
 
-	return slog.Default()
+	return nil
 }
 
 // NewHandler returns a singleton slog.Handler per scope.

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: 2025 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package logger provides contextual log features for Ion using slog interface
+// and zap backend.
+package logger
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/pion/ion/v2/internal/config"
+	"go.uber.org/zap"
+	"go.uber.org/zap/exp/zapslog"
+	"go.uber.org/zap/zapcore"
+)
+
+type ctxKey struct{}
+
+type Options struct {
+	DefaultLevel  string
+	Format        config.LogFormat
+	ScopeLevels   map[string]string
+	DefaultWriter config.WriterType
+}
+
+type LoggerFactory struct {
+	ws           zapcore.WriteSyncer
+	encoder      zapcore.Encoder
+	defaultLevel zap.AtomicLevel
+	scopeLevels  map[string]zap.AtomicLevel
+	cache        map[string]slog.Handler
+	rootLogger   *slog.Logger
+	mu           sync.RWMutex
+}
+
+// BuildWriteSyncer parses and build a Zap WriteSyncer.
+func BuildWriteSyncer(writer config.WriterType) (zapcore.WriteSyncer, error) {
+	switch strings.ToLower(string(writer)) {
+	case string(config.WriterStderr):
+		return zapcore.AddSync(os.Stderr), nil
+	case string(config.WriterStdout):
+		return zapcore.AddSync(os.Stdout), nil
+	default:
+		return nil, config.ErrInvalidWriterType
+	}
+}
+
+// BuildEncoder parses and builds a Zap encoder.
+func BuildEncoder(format config.LogFormat) (zapcore.Encoder, error) {
+	switch strings.ToLower(string(format)) {
+	case "text":
+		return zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()), nil
+	case "json", "":
+		return zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), nil
+	default:
+		return nil, config.ErrInvalidFormatType
+	}
+}
+
+// ParseZapLevel parses level from string to zapcore.Levels.
+func ParseZapLevel(level string) zapcore.Level {
+	switch strings.ToLower(level) {
+	case "debug":
+		return zapcore.DebugLevel
+	case "info", "":
+		return zapcore.InfoLevel
+	case "warn", "warning":
+		return zapcore.WarnLevel
+	case "error":
+		return zapcore.ErrorLevel
+	default:
+		return zapcore.InfoLevel
+	}
+}
+
+// NewLoggerFactory creates a new LoggerFactory.
+func NewLoggerFactory(opts Options) (*LoggerFactory, error) {
+	ws, err := BuildWriteSyncer(opts.DefaultWriter)
+	if err != nil {
+		return nil, err
+	}
+
+	encoder, err := BuildEncoder(opts.Format)
+	if err != nil {
+		return nil, err
+	}
+
+	defaultLevel := zap.NewAtomicLevelAt(ParseZapLevel(opts.DefaultLevel))
+	factory := &LoggerFactory{
+		ws:           ws,
+		encoder:      encoder,
+		defaultLevel: defaultLevel,
+		scopeLevels:  make(map[string]zap.AtomicLevel),
+		cache:        make(map[string]slog.Handler),
+	}
+
+	for scope, level := range opts.ScopeLevels {
+		factory.scopeLevels[scope] = zap.NewAtomicLevelAt(ParseZapLevel(level))
+	}
+
+	rootCore := zapcore.NewCore(encoder, ws, defaultLevel)
+	rootZap := zap.New(rootCore, zap.AddCaller())
+	rootBase := zapslog.NewHandler(rootZap.Core())
+	factory.rootLogger = slog.New(&ctxHandler{next: rootBase})
+
+	return factory, nil
+}
+
+// WithContext stores a logger in context and return copy of the context.
+func WithContext(ctx context.Context, l *slog.Logger) context.Context {
+	return context.WithValue(ctx, ctxKey{}, l)
+}
+
+// BuildLoggerForCtx creates a logger and bind it with
+// ctx appending with scope key value pair.
+func (f *LoggerFactory) BuildLoggerForCtx(ctx context.Context, scope string) context.Context {
+	h := f.newHandler(scope)
+	h = &ctxHandler{next: h, scope: scope}
+
+	return WithContext(ctx, slog.New(h))
+}
+
+// FromContext returns the logger stored in ctx or the factory root.
+func (f *LoggerFactory) FromContext(ctx context.Context) *slog.Logger {
+	if lg := retriveLoggerfromCtx(ctx); lg != nil {
+		return lg
+	}
+
+	return f.rootLogger
+}
+
+// RetriveLoggerfromCtx retrieves the logger associated with ctx
+// or returns slog.Default().
+func retriveLoggerfromCtx(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(ctxKey{}).(*slog.Logger); ok && l != nil {
+		return l
+	}
+
+	return slog.Default()
+}
+
+// NewHandler returns a singleton slog.Handler per scope.
+// The defult log level will be used unless specified in the config.
+func (f *LoggerFactory) newHandler(scope string) slog.Handler {
+	f.mu.RLock()
+	if handler, ok := f.cache[scope]; ok {
+		f.mu.RUnlock()
+
+		return handler
+	}
+	f.mu.RUnlock()
+
+	level := f.defaultLevel
+	f.mu.RLock()
+	if sl, ok := f.scopeLevels[scope]; ok {
+		level = sl
+	}
+	f.mu.RUnlock()
+
+	core := zapcore.NewCore(f.encoder, f.ws, level)
+	zl := zap.New(core, zap.AddCaller())
+
+	handler := zapslog.NewHandler(zl.Core())
+	f.mu.Lock()
+	f.cache[scope] = handler
+	f.mu.Unlock()
+
+	return handler
+}
+
+// Custom handler for logger per scope
+
+type ctxHandler struct {
+	next  slog.Handler
+	scope string // optional
+}
+
+func (h *ctxHandler) Enabled(ctx context.Context, lvl slog.Level) bool {
+	return h.next.Enabled(ctx, lvl)
+}
+
+func (h *ctxHandler) Handle(ctx context.Context, rec slog.Record) error {
+	if h.scope != "" {
+		rec.AddAttrs(slog.String("module", h.scope))
+	}
+
+	return h.next.Handle(ctx, rec)
+}
+
+func (h *ctxHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &ctxHandler{next: h.next.WithAttrs(attrs), scope: h.scope}
+}
+
+func (h *ctxHandler) WithGroup(name string) slog.Handler {
+	return &ctxHandler{next: h.next.WithGroup(name), scope: h.scope}
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -124,7 +124,7 @@ func (f *LoggerFactory) BuildLoggerForCtx(ctx context.Context, scope string) con
 	return WithContext(ctx, slog.New(h))
 }
 
-// FromContext returns the logger stored in ctx or the factory root.
+// FromCtx returns the logger stored in ctx or the factory root.
 func (f *LoggerFactory) FromCtx(ctx context.Context) *slog.Logger {
 	if lg := retriveLoggerfromCtx(ctx); lg != nil {
 		return lg

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -125,7 +125,7 @@ func (f *LoggerFactory) BuildLoggerForCtx(ctx context.Context, scope string) con
 }
 
 // FromContext returns the logger stored in ctx or the factory root.
-func (f *LoggerFactory) FromContext(ctx context.Context) *slog.Logger {
+func (f *LoggerFactory) FromCtx(ctx context.Context) *slog.Logger {
 	if lg := retriveLoggerfromCtx(ctx); lg != nil {
 		return lg
 	}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2025 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package logger
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/pion/ion/v2/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildWriteSyncer(t *testing.T) {
+	t.Run("stdout", func(t *testing.T) {
+		ws, err := BuildWriteSyncer(config.WriterStdout)
+		require.NoError(t, err)
+		require.NotNil(t, ws)
+	})
+
+	t.Run("stderr", func(t *testing.T) {
+		ws, err := BuildWriteSyncer(config.WriterStderr)
+		require.NoError(t, err)
+		require.NotNil(t, ws)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := BuildWriteSyncer(config.WriterType("not-a-writer"))
+		require.Error(t, err)
+	})
+}
+
+func TestBuildEncoder(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		enc, err := BuildEncoder(config.LogFormat("json"))
+		require.NoError(t, err)
+		require.NotNil(t, enc)
+	})
+
+	t.Run("text", func(t *testing.T) {
+		enc, err := BuildEncoder(config.LogFormat("text"))
+		require.NoError(t, err)
+		require.NotNil(t, enc)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := BuildEncoder(config.LogFormat("xml"))
+		require.Error(t, err)
+	})
+}
+
+func TestParseZapLevel(t *testing.T) {
+	cases := map[string]int8{
+		"debug":    -1,
+		"info":     0,
+		"":         0,
+		"warn":     1,
+		"warning":  1,
+		"error":    2,
+		"garbage!": 0,
+	}
+	for in, want := range cases {
+		lvl := ParseZapLevel(in)
+		require.Equal(t, want, int8(lvl), "input=%q", in)
+	}
+}
+
+func TestNewLoggerFactory(t *testing.T) {
+	opts := Options{
+		DefaultLevel:  "info",
+		Format:        config.LogFormat("json"),
+		ScopeLevels:   map[string]string{},
+		DefaultWriter: config.WriterStdout,
+	}
+	f, err := NewLoggerFactory(opts)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	require.NotNil(t, f.rootLogger)
+}
+
+// NOTE: Build the factory *inside* this capture so zap binds to the pipe.
+func captureStdout(fn func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	b, _ := io.ReadAll(r)
+	_ = r.Close()
+
+	return string(b)
+}
+
+func TestScopeLevelAndModuleAttr(t *testing.T) {
+	opts := Options{
+		DefaultLevel:  "info", // debug should be dropped unless overridden
+		Format:        config.LogFormat("json"),
+		DefaultWriter: config.WriterStdout,
+		ScopeLevels: map[string]string{
+			"sfu": "debug", // override for this scope only
+		},
+	}
+
+	out := captureStdout(func() {
+		f, err := NewLoggerFactory(opts)
+		require.NoError(t, err)
+
+		// Scope with debug level enabled.
+		ctx := f.BuildLoggerForCtx(context.Background(), "sfu")
+		l1 := f.FromCtx(ctx)
+		l1.Debug("sfu-debug", slog.String("k", "v"))
+
+		// Scope without override should drop debug at default info level.
+		ctx2 := f.BuildLoggerForCtx(context.Background(), "other")
+		l2 := f.FromCtx(ctx2)
+		l2.Debug("drop-me", slog.String("x", "y"))
+
+		// Emit an info from "other" to ensure we get at least one record from it.
+		l2.Info("visible-info")
+	})
+
+	// Should include the debug message and module tag for "sfu".
+	require.Contains(t, out, `"msg":"sfu-debug"`, "expected debug message for sfu")
+	require.Contains(t, out, `"module":"sfu"`, "expected module attribute for sfu")
+
+	// "drop-me" should not appear because default scope is info.
+	require.NotContains(t, out, `"msg":"drop-me"`, "did not expect debug message for default scope")
+
+	// Sanity: the info from "other" should appear and carry module=other.
+	require.Contains(t, out, `"msg":"visible-info"`, "expected info message for other scope")
+	require.Contains(t, out, `"module":"other"`, "expected module attribute for other")
+}
+
+func TestHandlerSingletonPerScope(t *testing.T) {
+	f, err := NewLoggerFactory(Options{
+		DefaultLevel:  "info",
+		Format:        config.LogFormat("json"),
+		DefaultWriter: config.WriterStdout,
+	})
+	require.NoError(t, err)
+
+	h1 := f.newHandler("auth")
+	h2 := f.newHandler("auth")
+	h3 := f.newHandler("sfu")
+
+	require.Same(t, h1, h2, "expected same handler instance for identical scope")
+	require.NotSame(t, h1, h3, "expected different handler instances for different scopes")
+}
+
+func TestWithContextAndFromCtx(t *testing.T) {
+	factory, err := NewLoggerFactory(Options{
+		DefaultLevel:  "info",
+		Format:        config.LogFormat("json"),
+		DefaultWriter: config.WriterStdout,
+	})
+	require.NoError(t, err)
+
+	// Put a custom logger into context and ensure FromCtx returns it.
+	buf := &bytes.Buffer{}
+	custom := slog.New(slog.NewTextHandler(buf, nil))
+	ctx := WithContext(context.Background(), custom)
+
+	got := factory.FromCtx(ctx)
+	require.Same(t, custom, got, "FromCtx should return logger stored in context")
+
+	// When nothing in context, FromCtx should return factory root (non-nil).
+	got2 := factory.FromCtx(context.Background())
+	require.NotNil(t, got2)
+}
+
+func TestRetriveLoggerfromCtx_Default(t *testing.T) {
+	l := retriveLoggerfromCtx(context.Background())
+	require.Nil(t, l, "expected nil when context has no logger")
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/pion/ion/v2/internal/config"
@@ -97,6 +98,9 @@ func captureStdout(fn func()) string {
 }
 
 func TestScopeLevelAndModuleAttr(t *testing.T) {
+	if runtime.GOOS == "js" {
+		t.Skip("stdout/stderr capture not supported under js/wasm; skip")
+	}
 	opts := Options{
 		DefaultLevel:  "info", // debug should be dropped unless overridden
 		Format:        config.LogFormat("json"),


### PR DESCRIPTION
#### Description
Logger module implements contextual logging with slog+zap with different log level control for every scope.
The main APIs are:
`BuildLoggerForCtx`: creates a singleton logger and binds it with a context appending with a scope key value pair.
`FromCtxt`: Return the logger for a context + scope or return the default logger.
#### Reference issue
Partially #3 
#### Potential TODOs (After architectural review)
- Add tests
- Expose change level for dynamic logging level changes.
