### PR TITLE
Draft ICE

### DIFF
--- a/cmd/ice/main.go
+++ b/cmd/ice/main.go
@@ -323,7 +323,7 @@ func setupTLSEndpoint(
 
 	tlsLn := tls.NewListener(baseLn, &tls.Config{
 		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
+		MinVersion:   tlsCfg.Version,
 	})
 
 	// Add to closer stack only after everything succeeded.
@@ -338,7 +338,7 @@ func setupTLSEndpoint(
 // makeRelay returns the RelayAddressGenerator for configuration.
 func makeRelay(cfg ionICE.TURNConfig) turn.RelayAddressGenerator {
 	return &turn.RelayAddressGeneratorPortRange{
-		Address:      "0.0.0.0",
+		Address:      cfg.Address,
 		MinPort:      cfg.PortRangeMin,
 		MaxPort:      cfg.PortRangeMax,
 		RelayAddress: net.ParseIP(cfg.PublicIP),

--- a/cmd/ice/main.go
+++ b/cmd/ice/main.go
@@ -1,0 +1,386 @@
+// SPDX-FileCopyrightText: 2025 The Pion community
+// SPDX-License-Identifier: MIT
+
+// Package main wires Ion's ICE config into a single-binary STUN/TURN service.
+// If TURN is enabled, it will also serve STUN Binding on the same port(s).
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/pion/ion/v2/internal/config"
+	ionICE "github.com/pion/ion/v2/internal/ice"
+	"github.com/pion/ion/v2/internal/logger"
+	"github.com/pion/turn/v4"
+	"github.com/spf13/pflag"
+)
+
+var errMissingTLSKeyPair = errors.New("turn.tls enabled but cert/key not provided")
+
+func main() {
+	config.RegisterFlags(pflag.CommandLine)
+	pflag.Parse()
+
+	cfg, err := config.Load(pflag.CommandLine)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config error: %v\n", err)
+		os.Exit(1)
+	}
+
+	lf, err := logger.NewLoggerFactory(
+		logger.Options{
+			DefaultWriter: config.WriterStderr,
+			Format:        cfg.Telemetry.Logs.Format,
+			DefaultLevel:  cfg.Telemetry.Logs.Level,
+		},
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "loggerFactory error: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx := lf.BuildLoggerForCtx(context.Background(), "ion-iceServer")
+	lgr := lf.FromCtx(ctx)
+
+	if cfg.ICE.ICEMode() == ionICE.Disabled {
+		lgr.Info("both STUN and TURN disabled; exit")
+		os.Exit(0)
+	}
+
+	// Graceful shutdown context via signals.
+	ctx, stopSignals := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stopSignals()
+
+	// STUN-only endpoints (separate from TURN/STUN shared ones).
+	_, stopSTUN, err := startStunOnlyServer(ctx, cfg.ICE, lf)
+	if err != nil {
+		lgr.Error(fmt.Sprintf("stun-only server: %v", err))
+	}
+	if stopSTUN != nil {
+		defer stopSTUN()
+	}
+
+	// TURN(+STUN on same port) endpoints.
+	_, stopTURNSTUN, err := startTURNSTUNServer(ctx, cfg.ICE, lf)
+	if err != nil {
+		lgr.Error(fmt.Sprintf("turn-stun server: %v", err))
+	}
+	if stopTURNSTUN != nil {
+		defer stopTURNSTUN()
+	}
+
+	// Block until signal.
+	<-ctx.Done()
+}
+
+// closerStack closes in LIFO order.
+type closerStack struct {
+	list []io.Closer
+}
+
+func (c *closerStack) Add(cs ...io.Closer) {
+	c.list = append(c.list, cs...)
+}
+
+func (c *closerStack) CloseAll() {
+	for i := len(c.list) - 1; i >= 0; i-- {
+		_ = c.list[i].Close()
+	}
+}
+
+// startStunOnlyServer starts a STUN Binding server on dedicated endpoints (no TURN).
+func startStunOnlyServer(
+	parent context.Context,
+	cfg ionICE.ICEConfig,
+	lf *logger.LoggerFactory,
+) (*turn.Server, func(), error) {
+	ctx := lf.BuildLoggerForCtx(parent, "stun-only")
+	lgr := lf.FromCtx(ctx)
+
+	lc := net.ListenConfig{}
+	var (
+		pcConfs []turn.PacketConnConfig
+		lnConfs []turn.ListenerConfig // reserved for future TCP support
+	)
+
+	udpAddr, err := cfg.STUNOnlyEndpoint(ionICE.NetworkUDP) // nolint:contextcheck
+	if err != nil {
+		lgr.Error(err.Error())
+
+		return nil, nil, err
+	}
+	tcpAddr, err := cfg.STUNOnlyEndpoint(ionICE.NetworkTCP) // nolint:contextcheck
+	if err != nil {
+		lgr.Error(err.Error())
+
+		return nil, nil, err
+	}
+
+	if udpAddr == "" { // no implementation on TCP yet
+		return nil, nil, nil
+	}
+
+	var closers closerStack
+
+	if udpAddr != "" {
+		lgr.Info(fmt.Sprintf("STUN-only UDP endpoint on %s", udpAddr))
+
+		var pc net.PacketConn
+		pc, err = lc.ListenPacket(ctx, "udp", udpAddr)
+		if err != nil {
+			lgr.Error(err.Error())
+			closers.CloseAll()
+
+			return nil, nil, err
+		}
+		pcConfs = append(pcConfs, turn.PacketConnConfig{PacketConn: pc})
+		closers.Add(pc)
+	}
+
+	if tcpAddr != "" {
+		// Not yet implemented by this binary (pion/turn supports TCP for TURN,
+		// but STUN-only over TCP here is intentionally deferred).
+		lgr.Warn("STUN-only over TCP not supported yet")
+	}
+
+	srv, err := turn.NewServer(turn.ServerConfig{
+		PacketConnConfigs: pcConfs,
+		ListenerConfigs:   lnConfs,
+		LoggerFactory:     lf.NewPionAdaptor(ctx),
+	})
+	if err != nil {
+		lgr.Error(err.Error())
+		closers.CloseAll()
+
+		return nil, nil, err
+	}
+
+	stop := func() {
+		_ = srv.Close()
+		closers.CloseAll()
+	}
+
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
+
+	return srv, stop, nil
+}
+
+// startTURNSTUNServer starts TURN (and STUN on same ports) based on config.
+func startTURNSTUNServer( //nolint:cyclop
+	parent context.Context,
+	cfg ionICE.ICEConfig,
+	lf *logger.LoggerFactory,
+) (*turn.Server, func(), error) {
+	ctx := lf.BuildLoggerForCtx(parent, "turn-stun")
+	lgr := lf.FromCtx(ctx)
+	lc := net.ListenConfig{}
+
+	udpAddr, err := cfg.TURNSTUNEndpoint(ionICE.NetworkUDP) // nolint:contextcheck
+	if err != nil {
+		lgr.Error(err.Error())
+
+		return nil, nil, err
+	}
+	tcpAddr, err := cfg.TURNSTUNEndpoint(ionICE.NetworkTCP) // nolint:contextcheck
+	if err != nil {
+		lgr.Error(err.Error())
+
+		return nil, nil, err
+	}
+	tlsAddr := cfg.TURN.TLS.Endpoint
+
+	if udpAddr == "" && tcpAddr == "" && tlsAddr == "" {
+		lgr.Info("no TURN-STUN server configured")
+
+		return nil, nil, nil
+	}
+
+	realm := cfg.TURN.Realm
+	authHandler := makeAuth(ctx, lf, cfg.TURN)
+	relayGen := makeRelay(cfg.TURN)
+
+	var (
+		pcConfs []turn.PacketConnConfig
+		lnConfs []turn.ListenerConfig
+		closers closerStack
+	)
+
+	// UDP
+	if udpAddr != "" {
+		lgr.Info(fmt.Sprintf("TURN-STUN UDP endpoint on %s (realm=%s)", udpAddr, realm))
+		pc, errUDP := lc.ListenPacket(ctx, "udp", udpAddr)
+		if errUDP != nil {
+			lgr.Error(errUDP.Error())
+			closers.CloseAll()
+
+			return nil, nil, fmt.Errorf("udp listen %q: %w", udpAddr, errUDP)
+		}
+		pcConfs = append(pcConfs, turn.PacketConnConfig{
+			PacketConn:            pc,
+			RelayAddressGenerator: relayGen,
+		})
+		closers.Add(pc)
+	}
+
+	// TCP
+	if tcpAddr != "" {
+		lgr.Info(fmt.Sprintf("TURN-STUN TCP endpoint on %s (realm=%s)", tcpAddr, realm))
+		ln, errTCP := lc.Listen(ctx, "tcp", tcpAddr)
+		if errTCP != nil {
+			lgr.Error(errTCP.Error())
+			closers.CloseAll()
+
+			return nil, nil, fmt.Errorf("tcp listen %q: %w", tcpAddr, errTCP)
+		}
+		lnConfs = append(lnConfs, turn.ListenerConfig{
+			Listener:              ln,
+			RelayAddressGenerator: relayGen,
+		})
+		closers.Add(ln)
+	}
+
+	// TLS
+	if tlsAddr != "" {
+		lgr.Info(fmt.Sprintf("TURN TLS endpoint on %s (realm=%s)", tlsAddr, realm))
+		lnConf, errTLS := setupTLSEndpoint(ctx, lc, tlsAddr, cfg.TURN.TLS, relayGen, lgr, &closers)
+		if errTLS != nil {
+			lgr.Error(errTLS.Error())
+			closers.CloseAll()
+
+			return nil, nil, errTLS
+		}
+		lnConfs = append(lnConfs, lnConf)
+	}
+
+	srv, err := turn.NewServer(turn.ServerConfig{
+		Realm:             realm,
+		LoggerFactory:     lf.NewPionAdaptor(ctx),
+		AuthHandler:       authHandler,
+		PacketConnConfigs: pcConfs,
+		ListenerConfigs:   lnConfs,
+	})
+	if err != nil {
+		lgr.Error(err.Error())
+		closers.CloseAll()
+
+		return nil, nil, err
+	}
+
+	stop := func() {
+		_ = srv.Close()
+		closers.CloseAll()
+	}
+
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
+
+	return srv, stop, nil
+}
+
+// setupTLSEndpoint wires a TLS listener for TURN and returns a ListenerConfig.
+// It only adds listeners to closers on success; on error, the caller can CloseAll().
+func setupTLSEndpoint(
+	ctx context.Context,
+	lc net.ListenConfig,
+	tlsAddr string,
+	tlsCfg ionICE.TLSConfig,
+	relayGen turn.RelayAddressGenerator,
+	lgr *slog.Logger,
+	closers *closerStack,
+) (turn.ListenerConfig, error) {
+	if tlsCfg.Cert == "" || tlsCfg.Key == "" {
+		lgr.Error(errMissingTLSKeyPair.Error())
+
+		return turn.ListenerConfig{}, errMissingTLSKeyPair
+	}
+
+	baseLn, err := lc.Listen(ctx, "tcp", tlsAddr)
+	if err != nil {
+		return turn.ListenerConfig{}, fmt.Errorf("tls listen %q: %w", tlsAddr, err)
+	}
+
+	cert, err := tls.LoadX509KeyPair(tlsCfg.Cert, tlsCfg.Key)
+	if err != nil {
+		_ = baseLn.Close()
+
+		return turn.ListenerConfig{}, fmt.Errorf("load tls cert: %w", err)
+	}
+
+	tlsLn := tls.NewListener(baseLn, &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	})
+
+	// Add to closer stack only after everything succeeded.
+	closers.Add(tlsLn, baseLn)
+
+	return turn.ListenerConfig{
+		Listener:              tlsLn,
+		RelayAddressGenerator: relayGen,
+	}, nil
+}
+
+// makeRelay returns the RelayAddressGenerator for configuration.
+func makeRelay(cfg ionICE.TURNConfig) turn.RelayAddressGenerator {
+	return &turn.RelayAddressGeneratorPortRange{
+		Address:      "0.0.0.0",
+		MinPort:      cfg.PortRangeMin,
+		MaxPort:      cfg.PortRangeMax,
+		RelayAddress: net.ParseIP(cfg.PublicIP),
+	}
+}
+
+// makeAuth returns an AuthHandler for TURN based on config.
+func makeAuth(ctx context.Context, lf *logger.LoggerFactory, cfg ionICE.TURNConfig) turn.AuthHandler {
+	lgr := lf.FromCtx(ctx)
+
+	switch strings.ToLower(strings.TrimSpace(cfg.Auth)) {
+	case "", "static":
+		users := map[string]string{}
+		if cfg.User != "" {
+			users[cfg.User] = cfg.Password
+		}
+
+		return func(username, realm string, _ net.Addr) ([]byte, bool) {
+			if realm != cfg.Realm {
+				return nil, false
+			}
+			pw, ok := users[username]
+			if !ok {
+				return nil, false
+			}
+
+			return turn.GenerateAuthKey(username, realm, pw), true
+		}
+
+	case "long-term", "longterm", "long_term":
+		secret := strings.TrimSpace(cfg.Secret)
+		if secret == "" {
+			lgr.Warn("long-term auth requested but secret is empty; rejecting all auth")
+
+			return func(string, string, net.Addr) ([]byte, bool) { return nil, false }
+		}
+		// nolint:contextcheck // pion/turn logger doesn't take context.
+		return turn.NewLongTermAuthHandler(secret, lf.NewPionAdaptor(ctx).NewLogger("ion-iceServer"))
+
+	default:
+		lgr.Warn(fmt.Sprintf("unknown auth=%q; rejecting all auth", cfg.Auth))
+
+		return func(string, string, net.Addr) ([]byte, bool) { return nil, false }
+	}
+}

--- a/cmd/ice/main_test.go
+++ b/cmd/ice/main_test.go
@@ -1,0 +1,582 @@
+// SPDX-FileCopyrightText: 2025 The Pion community
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/pion/ion/v2/internal/config"
+	ionICE "github.com/pion/ion/v2/internal/ice"
+	"github.com/pion/ion/v2/internal/logger"
+	"github.com/pion/turn/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// --- shared test constants (avoid goconst) ---.
+const (
+	testScopeGeneric = "test"
+
+	loopbackEphemeral = "127.0.0.1:0"
+	anyUDPEphemeral   = "0.0.0.0:0"
+
+	realmIon   = "ion"
+	authStatic = "static"
+
+	userAlice   = "alice"
+	passSecret  = "secret"
+	passPwd     = "password"
+	passCorrect = "correct-password"
+
+	pubIP1 = "127.0.0.1"
+	pubIP2 = "127.0.0.2"
+	pubIP3 = "127.0.0.3"
+
+	portMin50000 = 50000
+	portMax50010 = 50010
+	portMax50005 = 50005
+
+	swIonTests = "ion-ice-tests"
+)
+
+// --- helpers ---
+
+func safeClose(t *testing.T, c io.Closer) {
+	t.Helper()
+	if c == nil {
+		return
+	}
+
+	if err := c.Close(); err != nil {
+		t.Logf("failed to close %T: %v", c, err)
+	}
+}
+
+func testLoggerFactory(t *testing.T) *logger.LoggerFactory {
+	t.Helper()
+	lf, err := logger.NewLoggerFactory(logger.Options{
+		DefaultWriter: config.WriterStderr,
+		Format:        config.LogFormatText,
+		DefaultLevel:  "debug",
+	})
+	require.NoError(t, err)
+
+	return lf
+}
+
+// self-signed cert to temp files, returns paths.
+func writeSelfSignedCert(t *testing.T, dir string) (certFile, keyFile string) {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName:   "localhost",
+			Organization: []string{"ion-tests"},
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	certOut := filepath.Join(dir, "cert.pem")
+	keyOut := filepath.Join(dir, "key.pem")
+
+	{
+		f, err := os.Create(certOut) // #nosec G304
+		require.NoError(t, err)
+		defer safeClose(t, f)
+		require.NoError(t, pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	}
+	{
+		f, err := os.Create(keyOut) // #nosec G304
+		require.NoError(t, err)
+		defer safeClose(t, f)
+		b := x509.MarshalPKCS1PrivateKey(priv)
+		require.NoError(t, pem.Encode(f, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: b}))
+	}
+
+	return certOut, keyOut
+}
+
+// --- tests ---
+
+func TestStartStunOnlyServer_NoneConfigured(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), testScopeGeneric)
+
+	// STUN disabled → STUNOnlyEndpoint("") should be empty via config
+	cfg := ionICE.DefaultICEConfig()
+	cfg.STUN.Enabled = false
+	cfg.TURN.Enabled = false
+
+	srv, stop, err := startStunOnlyServer(ctx, cfg, lf)
+	require.NoError(t, err)
+	require.Nil(t, srv)
+	require.Nil(t, stop)
+}
+
+func TestStartStunOnlyServer_UDPOnly_Ephemeral(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), testScopeGeneric)
+
+	cfg := ionICE.DefaultICEConfig()
+	cfg.STUN.Enabled = true
+	cfg.TURN.Enabled = false
+	// Explicit UDP endpoint, TCP empty
+	cfg.STUN.UDPEndpoint = loopbackEphemeral
+	cfg.STUN.TCPEndpoint = ""
+
+	srv, stop, err := startStunOnlyServer(ctx, cfg, lf)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	require.NotNil(t, stop)
+
+	// Stop should be idempotent & not panic
+	stop()
+}
+
+func TestStartTURNSTUNServer_NoneConfigured(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), testScopeGeneric)
+
+	cfg := ionICE.DefaultICEConfig()
+	cfg.STUN.Enabled = false
+	cfg.TURN.Enabled = false
+	cfg.TURN.TLS.Endpoint = ""
+
+	srv, stop, err := startTURNSTUNServer(ctx, cfg, lf)
+	require.NoError(t, err)
+	require.Nil(t, srv)
+	require.Nil(t, stop)
+}
+
+func TestStartTURNSTUNServer_UDP_TCP_Ephemeral(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), testScopeGeneric)
+
+	cfg := ionICE.DefaultICEConfig()
+	cfg.STUN.Enabled = true
+	cfg.TURN.Enabled = true
+	// Share UDP/TCP ports (same-port STUN+TURN)
+	cfg.STUN.UDPEndpoint = loopbackEphemeral
+	cfg.TURN.UDPEndpoint = cfg.STUN.UDPEndpoint
+	cfg.STUN.TCPEndpoint = loopbackEphemeral
+	cfg.TURN.TCPEndpoint = cfg.STUN.TCPEndpoint
+	cfg.TURN.Realm = realmIon
+	cfg.TURN.Auth = authStatic
+	cfg.TURN.User = userAlice
+	cfg.TURN.Password = passPwd
+	cfg.TURN.PortRangeMin = portMin50000
+	cfg.TURN.PortRangeMax = portMax50010
+	cfg.TURN.PublicIP = pubIP1
+
+	srv, stop, err := startTURNSTUNServer(ctx, cfg, lf)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	require.NotNil(t, stop)
+	stop()
+}
+
+func TestStartTURNSTUNServer_TLS_MissingCertKey_Err(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), testScopeGeneric)
+
+	cfg := ionICE.DefaultICEConfig()
+	cfg.STUN.Enabled = true
+	cfg.TURN.Enabled = true
+	cfg.STUN.UDPEndpoint = loopbackEphemeral
+	cfg.TURN.UDPEndpoint = cfg.STUN.UDPEndpoint
+	cfg.TURN.Realm = realmIon
+	cfg.TURN.Auth = authStatic
+	cfg.TURN.User = userAlice
+	cfg.TURN.Password = passPwd
+	cfg.TURN.TLS.Endpoint = loopbackEphemeral // enabled
+	cfg.TURN.TLS.Cert = ""                    // missing
+	cfg.TURN.TLS.Key = ""                     // missing
+
+	srv, stop, err := startTURNSTUNServer(ctx, cfg, lf)
+	require.Error(t, err)
+	require.Nil(t, srv)
+	require.Nil(t, stop)
+}
+
+func TestStartTURNSTUNServer_TLS_WithCertKey_OK(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), testScopeGeneric)
+
+	tmp := t.TempDir()
+	certFile, keyFile := writeSelfSignedCert(t, tmp)
+
+	cfg := ionICE.DefaultICEConfig()
+	cfg.STUN.Enabled = true
+	cfg.TURN.Enabled = true
+	cfg.STUN.UDPEndpoint = loopbackEphemeral
+	cfg.TURN.UDPEndpoint = cfg.STUN.UDPEndpoint
+	cfg.TURN.Realm = realmIon
+	cfg.TURN.Auth = authStatic
+	cfg.TURN.User = userAlice
+	cfg.TURN.Password = passPwd
+	cfg.TURN.TLS.Endpoint = loopbackEphemeral
+	cfg.TURN.TLS.Cert = certFile
+	cfg.TURN.TLS.Key = keyFile
+	cfg.TURN.PortRangeMin = portMin50000
+	cfg.TURN.PortRangeMax = portMax50005
+	cfg.TURN.PublicIP = pubIP1
+
+	srv, stop, err := startTURNSTUNServer(ctx, cfg, lf)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	require.NotNil(t, stop)
+	stop()
+}
+
+func TestMakeAuth_Static(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), testScopeGeneric)
+
+	tcfg := ionICE.TURNConfig{
+		Realm:    realmIon,
+		Auth:     authStatic,
+		User:     userAlice,
+		Password: passSecret,
+	}
+	h := makeAuth(ctx, lf, tcfg)
+
+	key, ok := h(userAlice, realmIon, &net.UDPAddr{})
+	require.True(t, ok)
+	require.NotNil(t, key)
+
+	_, ok = h("bob", realmIon, &net.UDPAddr{})
+	require.False(t, ok)
+
+	_, ok = h(userAlice, "wrong-realm", &net.UDPAddr{})
+	require.False(t, ok)
+}
+
+func TestMakeAuth_LongTerm_EmptySecret_RejectAll(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), testScopeGeneric)
+
+	tcfg := ionICE.TURNConfig{
+		Realm: realmIon,
+		Auth:  "longterm",
+		// Secret empty
+	}
+	h := makeAuth(ctx, lf, tcfg)
+
+	_, ok := h("any", realmIon, &net.UDPAddr{})
+	require.False(t, ok)
+}
+
+func TestMakeAuth_UnknownScheme_RejectAll(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), testScopeGeneric)
+
+	tcfg := ionICE.TURNConfig{
+		Realm: realmIon,
+		Auth:  "mystery-auth",
+	}
+	h := makeAuth(ctx, lf, tcfg)
+
+	_, ok := h("any", realmIon, &net.UDPAddr{})
+	require.False(t, ok)
+}
+
+func TestMakeRelay_PortRangeAndIP(t *testing.T) {
+	turnCfg := ionICE.TURNConfig{
+		PortRangeMin: 49000,
+		PortRangeMax: 49010,
+		PublicIP:     "203.0.113.10",
+	}
+	gen := makeRelay(turnCfg)
+
+	rg, ok := gen.(*turn.RelayAddressGeneratorPortRange)
+	require.True(t, ok)
+	require.Equal(t, uint16(49000), rg.MinPort)
+	require.Equal(t, uint16(49010), rg.MaxPort)
+	require.Equal(t, net.ParseIP("203.0.113.10"), rg.RelayAddress)
+}
+
+func TestStopIsIdempotent(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = lf.BuildLoggerForCtx(ctx, testScopeGeneric)
+
+	cfg := ionICE.DefaultICEConfig()
+	cfg.STUN.Enabled = true
+	cfg.TURN.Enabled = true
+	cfg.STUN.UDPEndpoint = loopbackEphemeral
+	cfg.TURN.UDPEndpoint = cfg.STUN.UDPEndpoint
+	cfg.TURN.Realm = realmIon
+	cfg.TURN.Auth = authStatic
+	cfg.TURN.User = userAlice
+	cfg.TURN.Password = passPwd
+	cfg.TURN.PublicIP = pubIP1
+
+	srv, stop, err := startTURNSTUNServer(ctx, cfg, lf)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	require.NotNil(t, stop)
+
+	// Cancel context triggers internal stop
+	cancel()
+	// Call stop again; should not panic
+	stop()
+}
+
+/***************
+ * Test helpers
+ ***************/
+
+func freeUDPAddr(t *testing.T) string {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", loopbackEphemeral) //nolint:noctx
+	require.NoError(t, err)
+	defer safeClose(t, pc)
+
+	return pc.LocalAddr().String()
+}
+
+func freeTCPAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", loopbackEphemeral) //nolint:noctx
+	require.NoError(t, err)
+	safeClose(t, ln)
+
+	return ln.Addr().String()
+}
+
+/*******************************
+ * TURN client integration tests
+ *******************************/
+
+// Allocates over UDP with correct static creds.
+func TestTURNClient_Allocate_UDP_Success(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), "test-turn-alloc-udp")
+
+	udpAddr := freeUDPAddr(t) // reserve/learn an ephemeral port, then release
+
+	// Configure server to listen on that known UDP addr; TURN+STUN same-port mode.
+	cfg := ionICE.DefaultICEConfig()
+	cfg.STUN.Enabled = true
+	cfg.TURN.Enabled = true
+	cfg.STUN.UDPEndpoint = udpAddr
+	cfg.TURN.UDPEndpoint = udpAddr
+	cfg.TURN.Realm = realmIon
+	cfg.TURN.Auth = authStatic
+	cfg.TURN.User = userAlice
+	cfg.TURN.Password = passPwd
+	cfg.TURN.PortRangeMin = portMin50000
+	cfg.TURN.PortRangeMax = portMax50010
+	cfg.TURN.PublicIP = pubIP2
+
+	// Start server
+	srv, stop, err := startTURNSTUNServer(ctx, cfg, lf)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	require.NotNil(t, stop)
+	defer stop()
+
+	// TURN client bound to an ephemeral local UDP socket
+	pconn, err := net.ListenPacket("udp4", anyUDPEphemeral) //nolint:noctx
+	require.NoError(t, err)
+	defer safeClose(t, pconn)
+
+	cl, err := turn.NewClient(&turn.ClientConfig{
+		STUNServerAddr: udpAddr,       // not needed here
+		TURNServerAddr: udpAddr,       // point to our server
+		Conn:           pconn,         // client's UDP socket
+		Username:       cfg.TURN.User, // static auth
+		Password:       cfg.TURN.Password,
+		Realm:          cfg.TURN.Realm,
+		LoggerFactory:  lf.NewPionAdaptor(ctx),
+		Software:       swIonTests,
+	})
+	require.NoError(t, err)
+	defer cl.Close()
+
+	require.NoError(t, cl.Listen())
+
+	// Allocate relay
+	relayConn, err := cl.Allocate()
+	require.NoError(t, err)
+	require.NotEmpty(t, relayConn.LocalAddr().String())
+	host, _, err := net.SplitHostPort(relayConn.LocalAddr().String())
+	require.NoError(t, err)
+	require.Equal(t, host, cfg.TURN.PublicIP)
+
+	// Smoke: binding request should return mapped addr
+	mapped, err := cl.SendBindingRequest()
+	require.NoError(t, err)
+	require.NotNil(t, mapped)
+}
+
+// Fails allocation with wrong password.
+func TestTURNClient_Allocate_UDP_BadCreds_Fails(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), "test-turn-alloc-badcreds")
+
+	udpAddr := freeUDPAddr(t)
+
+	cfg := ionICE.DefaultICEConfig()
+	cfg.STUN.Enabled = true
+	cfg.TURN.Enabled = true
+	cfg.STUN.UDPEndpoint = udpAddr
+	cfg.TURN.UDPEndpoint = udpAddr
+	cfg.TURN.Realm = realmIon
+	cfg.TURN.Auth = authStatic
+	cfg.TURN.User = userAlice
+	cfg.TURN.Password = passCorrect
+	cfg.TURN.PortRangeMin = portMin50000
+	cfg.TURN.PortRangeMax = portMax50010
+	cfg.TURN.PublicIP = pubIP2
+
+	srv, stop, err := startTURNSTUNServer(ctx, cfg, lf)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	require.NotNil(t, stop)
+	defer stop()
+
+	pconn, err := net.ListenPacket("udp4", anyUDPEphemeral) //nolint:noctx
+	require.NoError(t, err)
+	defer safeClose(t, pconn)
+
+	cl, err := turn.NewClient(&turn.ClientConfig{
+		TURNServerAddr: udpAddr,
+		Conn:           pconn,
+		Username:       userAlice,
+		Password:       "wrong-password",
+		Realm:          realmIon,
+		LoggerFactory:  lf.NewPionAdaptor(ctx),
+		Software:       swIonTests,
+	})
+	require.NoError(t, err)
+	defer cl.Close()
+
+	require.NoError(t, cl.Listen())
+	_, err = cl.Allocate()
+	require.Error(t, err)
+}
+
+func TestTURNClient_CreatePermission_UDP(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), "test-turn-permission")
+
+	udpAddr := freeUDPAddr(t)
+
+	cfg := ionICE.DefaultICEConfig()
+	cfg.STUN.Enabled = true
+	cfg.TURN.Enabled = true
+	cfg.STUN.UDPEndpoint = udpAddr
+	cfg.TURN.UDPEndpoint = udpAddr
+	cfg.TURN.Realm = realmIon
+	cfg.TURN.Auth = authStatic
+	cfg.TURN.User = userAlice
+	cfg.TURN.Password = passPwd
+	cfg.TURN.PortRangeMin = portMin50000
+	cfg.TURN.PortRangeMax = portMax50005
+	cfg.TURN.PublicIP = pubIP2
+
+	srv, stop, err := startTURNSTUNServer(ctx, cfg, lf)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	require.NotNil(t, stop)
+	defer stop()
+
+	pconn, err := net.ListenPacket("udp4", anyUDPEphemeral) //nolint:noctx
+	require.NoError(t, err)
+	defer safeClose(t, pconn)
+
+	cl, err := turn.NewClient(&turn.ClientConfig{
+		TURNServerAddr: udpAddr,
+		Conn:           pconn,
+		Username:       cfg.TURN.User,
+		Password:       cfg.TURN.Password,
+		Realm:          cfg.TURN.Realm,
+		LoggerFactory:  lf.NewPionAdaptor(ctx),
+		Software:       swIonTests,
+	})
+	require.NoError(t, err)
+	defer cl.Close()
+
+	require.NoError(t, cl.Listen())
+	_, err = cl.Allocate()
+	require.NoError(t, err)
+
+	// For permission target, we can just use localhost IP; TURN requires an IP
+	target := &net.UDPAddr{IP: net.ParseIP(pubIP1)}
+	require.NotNil(t, target)
+
+	require.NoError(t, cl.CreatePermission(target))
+}
+
+func TestTURNClient_Allocate_TCP_Success(t *testing.T) {
+	lf := testLoggerFactory(t)
+	ctx := lf.BuildLoggerForCtx(context.Background(), "test-turn-alloc-tcp")
+
+	tcpAddr := freeTCPAddr(t)
+
+	cfg := ionICE.DefaultICEConfig()
+	cfg.STUN.Enabled = true
+	cfg.TURN.Enabled = true
+	cfg.STUN.TCPEndpoint = tcpAddr
+	cfg.TURN.TCPEndpoint = tcpAddr
+	cfg.TURN.Realm = realmIon
+	cfg.TURN.Auth = authStatic
+	cfg.TURN.User = userAlice
+	cfg.TURN.Password = passPwd
+	cfg.TURN.PortRangeMin = portMin50000
+	cfg.TURN.PortRangeMax = portMax50010
+	cfg.TURN.PublicIP = pubIP3
+
+	srv, stop, err := startTURNSTUNServer(ctx, cfg, lf)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	require.NotNil(t, stop)
+	defer stop()
+
+	// For TCP, pion/turn’s client can be configured with a net.Conn
+	conn, err := net.DialTimeout("tcp", tcpAddr, 2*time.Second) //nolint:noctx
+	require.NoError(t, err)
+	defer safeClose(t, conn)
+
+	client, err := turn.NewClient(&turn.ClientConfig{
+		TURNServerAddr: tcpAddr,
+		Conn:           turn.NewSTUNConn(conn),
+		Username:       cfg.TURN.User,
+		Password:       cfg.TURN.Password,
+		Realm:          cfg.TURN.Realm,
+		LoggerFactory:  lf.NewPionAdaptor(ctx),
+		Software:       swIonTests,
+	})
+	require.NoError(t, err)
+	defer client.Close()
+	require.NoError(t, client.Listen())
+	relayConn, err := client.Allocate()
+	require.NoError(t, err)
+	require.NotEmpty(t, relayConn.LocalAddr().String())
+	host, _, err := net.SplitHostPort(relayConn.LocalAddr().String())
+	require.NoError(t, err)
+	require.Equal(t, host, cfg.TURN.PublicIP)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
+	github.com/pion/turn/v4 v4.1.1
 	github.com/pion/webrtc/v4 v4.1.6
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
@@ -30,7 +31,6 @@ require (
 	github.com/pion/srtp/v3 v3.0.8 // indirect
 	github.com/pion/stun/v3 v3.0.0 // indirect
 	github.com/pion/transport/v3 v3.0.8 // indirect
-	github.com/pion/turn/v4 v4.1.1 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
 	golang.org/x/net v0.45.0 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	ionICE "github.com/pion/ion/v2/internal/ice"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -77,6 +78,7 @@ type TelemetryConfig struct {
 }
 
 type Config struct {
+	ICE       ionICE.ICEConfig
 	Telemetry TelemetryConfig `mapstructure:"telemetry"`
 }
 
@@ -106,6 +108,7 @@ func DefaultConfig() Config {
 				},
 			},
 		},
+		ICE: ionICE.DefaultICEConfig(),
 	}
 }
 
@@ -142,6 +145,29 @@ func RegisterFlags(fs *pflag.FlagSet) {
 		"OTLP traces endpoint (e.g. host:4317)")
 	fs.Float64("telemetry.traces.otlp.sample_ratio", def.Telemetry.Traces.OTLP.SampleRatio,
 		"Tracing sampler ratio in [0.0,1.0]")
+
+	// ice.stun
+	fs.Bool("ice.stun.enabled", def.ICE.STUN.Enabled, "Enable embedded STUN server")
+	fs.String("ice.stun.udp_endpoint", def.ICE.STUN.UDPEndpoint, "STUN UDP bind (host:port or :port)")
+	fs.String("ice.stun.tcp_endpoint", def.ICE.STUN.TCPEndpoint, "STUN TCP bind (host:port or :port)")
+
+	// ice.turn
+	fs.Bool("ice.turn.enabled", def.ICE.TURN.Enabled, "Enable embedded TURN server")
+	fs.String("ice.turn.udp_endpoint", def.ICE.TURN.UDPEndpoint, "TURN UDP bind (host:port or :port)")
+	fs.String("ice.turn.tcp_endpoint", def.ICE.TURN.TCPEndpoint, "TURN TCP bind (host:port or :port)")
+	fs.String("ice.turn.public_ip", def.ICE.TURN.PublicIP, "Public IP return to TURN client")
+	fs.String("ice.turn.realm", def.ICE.TURN.Realm, "TURN realm")
+	fs.String("ice.turn.auth", def.ICE.TURN.Auth, "TURN auth mode (e.g. 'long-term'|'shared-secret')")
+	fs.String("ice.turn.user", def.ICE.TURN.User, "TURN static username (for long-term auth)")
+	fs.String("ice.turn.password", def.ICE.TURN.Password, "TURN static password (for long-term auth)")
+	fs.String("ice.turn.secret", def.ICE.TURN.Secret, "TURN shared secret (for time-limited creds)")
+	fs.Uint16("ice.turn.port_range_min", def.ICE.TURN.PortRangeMin, "TURN min port range")
+	fs.Uint16("ice.turn.port_range_max", def.ICE.TURN.PortRangeMin, "TURN max port range")
+
+	// ice.turn.tls
+	fs.String("ice.turn.tls.endpoint", def.ICE.TURN.TLS.Endpoint, "TURN TLS bind (host:port or :port)")
+	fs.String("ice.turn.tls.cert", def.ICE.TURN.TLS.Cert, "TURN TLS certificate file path")
+	fs.String("ice.turn.tls.key", def.ICE.TURN.TLS.Key, "TURN TLS private key file path")
 }
 
 // Load returns config struct for ION.
@@ -163,6 +189,22 @@ func Load(fs *pflag.FlagSet) (Config, error) {
 	vp.SetDefault("telemetry.traces.otlp.service_name", cfg.Telemetry.Traces.OTLP.ServiceName)
 	vp.SetDefault("telemetry.traces.otlp.endpoint", cfg.Telemetry.Traces.OTLP.Endpoint)
 	vp.SetDefault("telemetry.traces.otlp.sample_ratio", cfg.Telemetry.Traces.OTLP.SampleRatio)
+
+	vp.SetDefault("ice.stun.enabled", cfg.ICE.STUN.Enabled)
+	vp.SetDefault("ice.stun.udp_endpoint", cfg.ICE.STUN.UDPEndpoint)
+	vp.SetDefault("ice.stun.tcp_endpoint", cfg.ICE.STUN.TCPEndpoint)
+
+	vp.SetDefault("ice.turn.enabled", cfg.ICE.TURN.Enabled)
+	vp.SetDefault("ice.turn.udp_endpoint", cfg.ICE.TURN.UDPEndpoint)
+	vp.SetDefault("ice.turn.tcp_endpoint", cfg.ICE.TURN.TCPEndpoint)
+	vp.SetDefault("ice.turn.public_ip", (cfg.ICE.TURN.PublicIP))
+	vp.SetDefault("ice.turn.realm", cfg.ICE.TURN.Realm)
+	vp.SetDefault("ice.turn.auth", cfg.ICE.TURN.Auth)
+	vp.SetDefault("ice.turn.user", cfg.ICE.TURN.User)
+	vp.SetDefault("ice.turn.password", cfg.ICE.TURN.Password)
+	vp.SetDefault("ice.turn.secret", cfg.ICE.TURN.Secret)
+	vp.SetDefault("ice.turn.port_range_min", (cfg.ICE.TURN.PortRangeMin))
+	vp.SetDefault("ice.turn.port_range_max", (cfg.ICE.TURN.PortRangeMax))
 
 	// Env
 	vp.SetEnvPrefix("ION")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -163,11 +163,13 @@ func RegisterFlags(fs *pflag.FlagSet) {
 	fs.String("ice.turn.secret", def.ICE.TURN.Secret, "TURN shared secret (for time-limited creds)")
 	fs.Uint16("ice.turn.port_range_min", def.ICE.TURN.PortRangeMin, "TURN min port range")
 	fs.Uint16("ice.turn.port_range_max", def.ICE.TURN.PortRangeMin, "TURN max port range")
+	fs.String("ice.turn.address", def.ICE.TURN.Address, "TURN address")
 
 	// ice.turn.tls
 	fs.String("ice.turn.tls.endpoint", def.ICE.TURN.TLS.Endpoint, "TURN TLS bind (host:port or :port)")
 	fs.String("ice.turn.tls.cert", def.ICE.TURN.TLS.Cert, "TURN TLS certificate file path")
 	fs.String("ice.turn.tls.key", def.ICE.TURN.TLS.Key, "TURN TLS private key file path")
+	fs.Uint16("ice.turn.tls.version", def.ICE.TURN.TLS.Version, "TURN TLS version")
 }
 
 // Load returns config struct for ION.
@@ -205,6 +207,11 @@ func Load(fs *pflag.FlagSet) (Config, error) {
 	vp.SetDefault("ice.turn.secret", cfg.ICE.TURN.Secret)
 	vp.SetDefault("ice.turn.port_range_min", (cfg.ICE.TURN.PortRangeMin))
 	vp.SetDefault("ice.turn.port_range_max", (cfg.ICE.TURN.PortRangeMax))
+	vp.SetDefault("ice.turn.address", (cfg.ICE.TURN.Address))
+	vp.SetDefault("ice.turn.tls.endpoint", (cfg.ICE.TURN.TLS.Endpoint))
+	vp.SetDefault("ice.turn.tls.cert", (cfg.ICE.TURN.TLS.Cert))
+	vp.SetDefault("ice.turn.tls.key", (cfg.ICE.TURN.TLS.Key))
+	vp.SetDefault("ice.turn.tls.version", (cfg.ICE.TURN.TLS.Version))
 
 	// Env
 	vp.SetEnvPrefix("ION")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,7 +157,7 @@ func RegisterFlags(fs *pflag.FlagSet) {
 	fs.String("ice.turn.tcp_endpoint", def.ICE.TURN.TCPEndpoint, "TURN TCP bind (host:port or :port)")
 	fs.String("ice.turn.public_ip", def.ICE.TURN.PublicIP, "Public IP return to TURN client")
 	fs.String("ice.turn.realm", def.ICE.TURN.Realm, "TURN realm")
-	fs.String("ice.turn.auth", def.ICE.TURN.Auth, "TURN auth mode (e.g. 'long-term'|'shared-secret')")
+	fs.String("ice.turn.auth", def.ICE.TURN.Auth, "TURN auth mode (long-term|static)")
 	fs.String("ice.turn.user", def.ICE.TURN.User, "TURN static username (for long-term auth)")
 	fs.String("ice.turn.password", def.ICE.TURN.Password, "TURN static password (for long-term auth)")
 	fs.String("ice.turn.secret", def.ICE.TURN.Secret, "TURN shared secret (for time-limited creds)")
@@ -169,7 +169,7 @@ func RegisterFlags(fs *pflag.FlagSet) {
 	fs.String("ice.turn.tls.endpoint", def.ICE.TURN.TLS.Endpoint, "TURN TLS bind (host:port or :port)")
 	fs.String("ice.turn.tls.cert", def.ICE.TURN.TLS.Cert, "TURN TLS certificate file path")
 	fs.String("ice.turn.tls.key", def.ICE.TURN.TLS.Key, "TURN TLS private key file path")
-	fs.Uint16("ice.turn.tls.version", def.ICE.TURN.TLS.Version, "TURN TLS version")
+	fs.String("ice.turn.tls.version", def.ICE.TURN.TLS.Version, "TURN TLS version (TLS12|TLS13)")
 }
 
 // Load returns config struct for ION.
@@ -243,6 +243,11 @@ func Load(fs *pflag.FlagSet) (Config, error) {
 
 	if err := vp.UnmarshalExact(&cfg); err != nil {
 		return Config{}, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+
+	// Validate
+	if err := cfg.ICE.Validate(); err != nil {
+		return cfg, err
 	}
 
 	return cfg, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,7 +162,7 @@ func RegisterFlags(fs *pflag.FlagSet) {
 	fs.String("ice.turn.password", def.ICE.TURN.Password, "TURN static password (for long-term auth)")
 	fs.String("ice.turn.secret", def.ICE.TURN.Secret, "TURN shared secret (for time-limited creds)")
 	fs.Uint16("ice.turn.port_range_min", def.ICE.TURN.PortRangeMin, "TURN min port range")
-	fs.Uint16("ice.turn.port_range_max", def.ICE.TURN.PortRangeMin, "TURN max port range")
+	fs.Uint16("ice.turn.port_range_max", def.ICE.TURN.PortRangeMax, "TURN max port range")
 	fs.String("ice.turn.address", def.ICE.TURN.Address, "TURN address")
 
 	// ice.turn.tls

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,9 +246,20 @@ func Load(fs *pflag.FlagSet) (Config, error) {
 	}
 
 	// Validate
-	if err := cfg.ICE.Validate(); err != nil {
+	if err := cfg.Validate(); err != nil {
 		return cfg, err
 	}
 
 	return cfg, nil
+}
+
+func (cfg *Config) Validate() error {
+	// Base
+
+	// ICE
+	if err := cfg.ICE.Validate(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2025 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
-package config_test
+package config
 
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
-	"github.com/pion/ion/v2/internal/config"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -39,12 +39,7 @@ func resetViperAndEnv(t *testing.T) {
 func newFS(t *testing.T, args ...string) *pflag.FlagSet {
 	t.Helper()
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	// define only flags your loader expects/that we use here
-	fs.String("config", "", "config file path")
-	fs.String("telemetry.logs.level", "", "log level")
-	fs.String("telemetry.logs.format", "", "log format")
-	fs.String("telemetry.metrics.prometheus.addr", "", "prometheus bind addr")
-	// keep flags minimal; precedence is what we test
+	RegisterFlags(fs)
 	require.NoError(t, fs.Parse(args))
 
 	return fs
@@ -67,12 +62,26 @@ func TestDefaults(t *testing.T) {
 	resetViperAndEnv(t)
 
 	fs := newFS(t /* no args */)
-	cfg, err := config.Load(fs)
+	cfg, err := Load(fs)
 	require.NoError(t, err)
 
-	require.Equal(t, config.DefaultLogLevel, cfg.Telemetry.Logs.Level)
-	require.Equal(t, config.DefaultLogFormat, cfg.Telemetry.Logs.Format)
-	require.Equal(t, config.DefaultPrometheusAddr, cfg.Telemetry.Metrics.Prometheus.Addr)
+	require.Equal(t, DefaultLogLevel, cfg.Telemetry.Logs.Level)
+	require.Equal(t, DefaultLogFormat, cfg.Telemetry.Logs.Format)
+	require.Equal(t, DefaultPrometheusAddr, cfg.Telemetry.Metrics.Prometheus.Addr)
+}
+
+func TestLoadErr(t *testing.T) {
+	resetViperAndEnv(t)
+
+	fs := newFS(t /* no args */)
+	err := fs.Parse([]string{
+		"--ice.turn.enabled",
+		"--ice.turn.port_range_min=0",
+	})
+	require.NoError(t, err)
+	_, err = Load(fs)
+	require.Error(t, err)
+
 }
 
 func TestPriority_FileOverridesDefault(t *testing.T) {
@@ -81,7 +90,7 @@ func TestPriority_FileOverridesDefault(t *testing.T) {
 	path := writeTempConfigWithPromAddr(t, testFileAddr)
 	fs := newFS(t, "--config", path)
 
-	cfg, err := config.Load(fs)
+	cfg, err := Load(fs)
 	require.NoError(t, err)
 	require.Equal(t, testFileAddr, cfg.Telemetry.Metrics.Prometheus.Addr, "file should override default")
 }
@@ -94,7 +103,7 @@ func TestPriority_EnvOverridesFile(t *testing.T) {
 
 	fs := newFS(t, "--config", path)
 
-	cfg, err := config.Load(fs)
+	cfg, err := Load(fs)
 	require.NoError(t, err)
 	require.Equal(t, testEnvAddr, cfg.Telemetry.Metrics.Prometheus.Addr, "env should override file")
 }
@@ -108,7 +117,7 @@ func TestPriority_FlagOverridesEnvAndFile(t *testing.T) {
 	// Supply --config, env, and flag; flags win
 	fs := newFS(t, "--config", path, "--telemetry.metrics.prometheus.addr", testFlagAddr)
 
-	cfg, err := config.Load(fs)
+	cfg, err := Load(fs)
 	require.NoError(t, err)
 	require.Equal(t, testFlagAddr, cfg.Telemetry.Metrics.Prometheus.Addr, "flag should override env+file")
 }
@@ -127,6 +136,185 @@ func TestInvalidConfigFileKey(t *testing.T) {
 
 	fs := newFS(t, "--config", f.Name())
 
-	_, err = config.Load(fs)
+	_, err = Load(fs)
 	require.Error(t, err, "expected error for unknown key 'xxx'")
+}
+
+func TestRegisterFlags(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(fs)
+
+	def := DefaultConfig()
+
+	tests := []struct {
+		name     string
+		defValue string
+		usage    string
+	}{
+		{
+			name:     "config",
+			defValue: "",
+			usage:    "Path to config file (TOML)",
+		},
+		{
+			name:     "telemetry.logs.level",
+			defValue: def.Telemetry.Logs.Level,
+			usage:    "Log level (debug|info|warn|error)",
+		},
+		{
+			name:     "telemetry.logs.format",
+			defValue: string(def.Telemetry.Logs.Format),
+			usage:    "Log format (text|json)",
+		},
+		{
+			name:     "telemetry.metrics.prometheus.enabled",
+			defValue: strconv.FormatBool(def.Telemetry.Metrics.Prometheus.Enabled),
+			usage:    "Enable Prometheus metrics exporter (scrape endpoint)",
+		},
+		{
+			name:     "telemetry.metrics.prometheus.addr",
+			defValue: def.Telemetry.Metrics.Prometheus.Addr,
+			usage:    "Prometheus metrics bind address (host:port or :port)",
+		},
+		{
+			name:     "telemetry.metrics.otlp.enabled",
+			defValue: strconv.FormatBool(def.Telemetry.Metrics.OTLP.Enabled),
+			usage:    "Enable OTLP metrics exporter (push)",
+		},
+		{
+			name:     "telemetry.metrics.otlp.endpoint",
+			defValue: def.Telemetry.Metrics.OTLP.Endpoint,
+			usage:    "OTLP metrics endpoint (e.g. host:4317)",
+		},
+		{
+			name:     "telemetry.traces.otlp.enabled",
+			defValue: strconv.FormatBool(def.Telemetry.Traces.OTLP.Enabled),
+			usage:    "Enable OpenTelemetry tracing via OTLP",
+		},
+		{
+			name:     "telemetry.traces.otlp.service_name",
+			defValue: def.Telemetry.Traces.OTLP.ServiceName,
+			usage:    "Tracing service name",
+		},
+		{
+			name:     "telemetry.traces.otlp.endpoint",
+			defValue: def.Telemetry.Traces.OTLP.Endpoint,
+			usage:    "OTLP traces endpoint (e.g. host:4317)",
+		},
+		{
+			name:     "telemetry.traces.otlp.sample_ratio",
+			defValue: strconv.FormatFloat(def.Telemetry.Traces.OTLP.SampleRatio, 'f', -1, 64),
+			usage:    "Tracing sampler ratio in [0.0,1.0]",
+		},
+
+		// ice.stun
+		{
+			name:     "ice.stun.enabled",
+			defValue: strconv.FormatBool(def.ICE.STUN.Enabled),
+			usage:    "Enable embedded STUN server",
+		},
+		{
+			name:     "ice.stun.udp_endpoint",
+			defValue: def.ICE.STUN.UDPEndpoint,
+			usage:    "STUN UDP bind (host:port or :port)",
+		},
+		{
+			name:     "ice.stun.tcp_endpoint",
+			defValue: def.ICE.STUN.TCPEndpoint,
+			usage:    "STUN TCP bind (host:port or :port)",
+		},
+
+		// ice.turn
+		{
+			name:     "ice.turn.enabled",
+			defValue: strconv.FormatBool(def.ICE.TURN.Enabled),
+			usage:    "Enable embedded TURN server",
+		},
+		{
+			name:     "ice.turn.udp_endpoint",
+			defValue: def.ICE.TURN.UDPEndpoint,
+			usage:    "TURN UDP bind (host:port or :port)",
+		},
+		{
+			name:     "ice.turn.tcp_endpoint",
+			defValue: def.ICE.TURN.TCPEndpoint,
+			usage:    "TURN TCP bind (host:port or :port)",
+		},
+		{
+			name:     "ice.turn.public_ip",
+			defValue: def.ICE.TURN.PublicIP,
+			usage:    "Public IP return to TURN client",
+		},
+		{
+			name:     "ice.turn.realm",
+			defValue: def.ICE.TURN.Realm,
+			usage:    "TURN realm",
+		},
+		{
+			name:     "ice.turn.auth",
+			defValue: def.ICE.TURN.Auth,
+			usage:    "TURN auth mode (long-term|static)",
+		},
+		{
+			name:     "ice.turn.user",
+			defValue: def.ICE.TURN.User,
+			usage:    "TURN static username (for long-term auth)",
+		},
+		{
+			name:     "ice.turn.password",
+			defValue: def.ICE.TURN.Password,
+			usage:    "TURN static password (for long-term auth)",
+		},
+		{
+			name:     "ice.turn.secret",
+			defValue: def.ICE.TURN.Secret,
+			usage:    "TURN shared secret (for time-limited creds)",
+		},
+		{
+			name:     "ice.turn.port_range_min",
+			defValue: strconv.FormatUint(uint64(def.ICE.TURN.PortRangeMin), 10),
+			usage:    "TURN min port range",
+		},
+		{
+			name:     "ice.turn.port_range_max",
+			defValue: strconv.FormatUint(uint64(def.ICE.TURN.PortRangeMax), 10),
+			usage:    "TURN max port range",
+		},
+		{
+			name:     "ice.turn.address",
+			defValue: def.ICE.TURN.Address,
+			usage:    "TURN address",
+		},
+
+		// ice.turn.tls
+		{
+			name:     "ice.turn.tls.endpoint",
+			defValue: def.ICE.TURN.TLS.Endpoint,
+			usage:    "TURN TLS bind (host:port or :port)",
+		},
+		{
+			name:     "ice.turn.tls.cert",
+			defValue: def.ICE.TURN.TLS.Cert,
+			usage:    "TURN TLS certificate file path",
+		},
+		{
+			name:     "ice.turn.tls.key",
+			defValue: def.ICE.TURN.TLS.Key,
+			usage:    "TURN TLS private key file path",
+		},
+		{
+			name:     "ice.turn.tls.version",
+			defValue: def.ICE.TURN.TLS.Version,
+			usage:    "TURN TLS version (TLS12|TLS13)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := fs.Lookup(tt.name)
+			require.NotNil(t, f, "flag %q not registered", tt.name)
+			require.Equal(t, tt.defValue, f.DefValue, "default mismatch for %q", tt.name)
+			require.Equal(t, tt.usage, f.Usage, "usage mismatch for %q", tt.name)
+		})
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -81,7 +81,6 @@ func TestLoadErr(t *testing.T) {
 	require.NoError(t, err)
 	_, err = Load(fs)
 	require.Error(t, err)
-
 }
 
 func TestPriority_FileOverridesDefault(t *testing.T) {

--- a/internal/ice/config.go
+++ b/internal/ice/config.go
@@ -7,10 +7,11 @@ package ice
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/pion/ion/v2/internal/utils"
 )
 
 type (
@@ -301,10 +302,10 @@ func (cfg *ICEConfig) Validate() error {
 		if cfg.STUN.UDPEndpoint == "" && cfg.STUN.TCPEndpoint == "" {
 			return errEmptySTUNEndpoint
 		}
-		if err := validateEndpoint(cfg.STUN.UDPEndpoint); err != nil {
+		if err := utils.ValidateEndpoint(cfg.STUN.UDPEndpoint); err != nil {
 			return err
 		}
-		if err := validateEndpoint(cfg.STUN.TCPEndpoint); err != nil {
+		if err := utils.ValidateEndpoint(cfg.STUN.TCPEndpoint); err != nil {
 			return err
 		}
 	}
@@ -326,13 +327,13 @@ func validateTURN(cfg *TURNConfig) error {
 		return errEmptyTURNEndpoint
 	}
 
-	if err := validateEndpoint(cfg.UDPEndpoint); err != nil {
+	if err := utils.ValidateEndpoint(cfg.UDPEndpoint); err != nil {
 		return err
 	}
-	if err := validateEndpoint(cfg.TCPEndpoint); err != nil {
+	if err := utils.ValidateEndpoint(cfg.TCPEndpoint); err != nil {
 		return err
 	}
-	if err := validateEndpoint(cfg.TLS.Endpoint); err != nil {
+	if err := utils.ValidateEndpoint(cfg.TLS.Endpoint); err != nil {
 		return err
 	}
 
@@ -350,17 +351,6 @@ func validateTURN(cfg *TURNConfig) error {
 
 	if err := validateTLSConfig(&cfg.TLS); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func validateEndpoint(ep string) error {
-	if ep == "" {
-		return nil
-	}
-	if _, _, err := net.SplitHostPort(ep); err != nil {
-		return fmt.Errorf("%w: %w", errInvalidHostPort, err)
 	}
 
 	return nil
@@ -404,7 +394,7 @@ func validateTLSConfig(tlsCfg *TLSConfig) error {
 		return nil // TLS not enabled
 	}
 	// If any TLS param is set, enforce the full set.
-	if err := validateEndpoint(tlsCfg.Endpoint); err != nil {
+	if err := utils.ValidateEndpoint(tlsCfg.Endpoint); err != nil {
 		return err
 	}
 	if tlsCfg.Cert == "" || tlsCfg.Key == "" {

--- a/internal/ice/config.go
+++ b/internal/ice/config.go
@@ -7,6 +7,7 @@ package ice
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"strings"
 	"time"
@@ -359,7 +360,7 @@ func validateEndpoint(ep string) error {
 		return nil
 	}
 	if _, _, err := net.SplitHostPort(ep); err != nil {
-		return err
+		return fmt.Errorf("%w: %w", errInvalidHostPort, err)
 	}
 
 	return nil

--- a/internal/ice/config.go
+++ b/internal/ice/config.go
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: 2025 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package ice provides ICE, TURN, STUN services for Ion.
+package ice
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+type (
+	iceServerMode int
+	networkType   int
+)
+
+const (
+	Disabled iceServerMode = iota
+	STUNOnlyMode
+	TURNOnlyMode
+	STUNAndTURNMode
+)
+
+const (
+	NetworkUDP networkType = iota
+	NetworkTCP
+)
+
+const dnsTimeout = 150 * time.Millisecond
+
+const (
+	DefaultPortRangeMin = 50000
+	DefaultPortRangeMax = 52000
+)
+
+type ICEConfig struct {
+	STUN STUNConfig `mapstructure:"stun"`
+	TURN TURNConfig `mapstructure:"turn"`
+}
+
+type STUNConfig struct {
+	UDPEndpoint string `mapstructure:"udp_endpoint"`
+	TCPEndpoint string `mapstructure:"tcp_endpoint"`
+	Enabled     bool   `mapstructure:"enabled"`
+}
+
+type TURNConfig struct {
+	TLS          TLSConfig `mapstructure:"tls"`
+	UDPEndpoint  string    `mapstructure:"udp_endpoint"`
+	TCPEndpoint  string    `mapstructure:"tcp_endpoint"`
+	PublicIP     string    `mapstructure:"public_ip"`
+	Realm        string    `mapstructure:"realm"`
+	Auth         string    `mapstructure:"auth"`
+	User         string    `mapstructure:"user"`
+	Password     string    `mapstructure:"password"`
+	Secret       string    `mapstructure:"secret"`
+	PortRangeMin uint16    `mapstructure:"port_range_min"`
+	PortRangeMax uint16    `mapstructure:"port_range_max"`
+	Enabled      bool
+}
+
+type TLSConfig struct {
+	Endpoint string `mapstructure:"endpoint"`
+	Cert     string `mapstructure:"cert"`
+	Key      string `mapstructure:"key"`
+}
+
+func DefaultICEConfig() ICEConfig {
+	return ICEConfig{
+		STUN: STUNConfig{
+			Enabled:     false,
+			UDPEndpoint: ":3478",
+			TCPEndpoint: ":3478",
+		},
+		TURN: TURNConfig{
+			Enabled:      false,
+			UDPEndpoint:  ":3478",
+			TCPEndpoint:  ":3478",
+			PublicIP:     "",
+			Realm:        "ion",
+			PortRangeMin: DefaultPortRangeMin,
+			PortRangeMax: DefaultPortRangeMax,
+		},
+	}
+}
+
+func (cfg *ICEConfig) ICEMode() iceServerMode {
+	switch {
+	case cfg.STUN.Enabled && cfg.TURN.Enabled:
+		return STUNAndTURNMode
+	case cfg.TURN.Enabled:
+		return TURNOnlyMode
+	case cfg.STUN.Enabled:
+		return STUNOnlyMode
+	default:
+		return Disabled
+	}
+}
+
+// STUNOnlyEndpoint returns STUN only udp/tcp endpoint for the configuration.
+// Return empty string when no such endpoint exists.
+func (cfg *ICEConfig) STUNOnlyEndpoint(network networkType) (string, error) {
+	mode := cfg.ICEMode()
+	if mode == TURNOnlyMode {
+		return "", nil
+	}
+
+	var stunEp string
+	if network == NetworkUDP {
+		stunEp = cfg.STUN.UDPEndpoint
+	} else {
+		stunEp = cfg.STUN.TCPEndpoint
+	}
+
+	if mode == STUNOnlyMode || stunEp == "" {
+		return stunEp, nil
+	}
+	// both stun and turn enabled and stun endpoint is NOT empty string
+	var turnEp string
+	if network == NetworkUDP {
+		turnEp = cfg.TURN.UDPEndpoint
+	} else {
+		turnEp = cfg.TURN.TCPEndpoint
+	}
+	// check if we need to share
+	addressSame, err := sameAddr(turnEp, stunEp)
+	if err != nil {
+		return "", err
+	}
+	if addressSame { // empty turn ep is considerred here
+		return "", nil
+	} else {
+		return stunEp, nil
+	}
+}
+
+// TURNOnlyEndpoint returns TURN only udp/tcp endpoint for the configuration.
+// Return empty string when no such endpoint exists.
+func (cfg *ICEConfig) TURNOnlyEndpoint(network networkType) (string, error) {
+	mode := cfg.ICEMode()
+	if mode == STUNOnlyMode {
+		return "", nil
+	}
+
+	var turnEp string
+	if network == NetworkUDP {
+		turnEp = cfg.TURN.UDPEndpoint
+	} else {
+		turnEp = cfg.TURN.TCPEndpoint
+	}
+
+	if mode == STUNOnlyMode || turnEp == "" {
+		return turnEp, nil
+	}
+	// both stun and turn enabled and turn endpoint is NOT empty string
+	var stunEp string
+	if network == NetworkUDP {
+		stunEp = cfg.STUN.UDPEndpoint
+	} else {
+		stunEp = cfg.STUN.TCPEndpoint
+	}
+	// check if we need to share
+	addressSame, err := sameAddr(stunEp, turnEp)
+	if err != nil {
+		return "", err
+	}
+	if addressSame { // empty stun ep is considerred here
+		return "", nil
+	} else {
+		return turnEp, nil
+	}
+}
+
+// TURNSTUNEndpoint returns endpoint shared by boths services for the configuration.
+// Return empty string when no such endpoint exists.
+func (cfg *ICEConfig) TURNSTUNEndpoint(network networkType) (string, error) {
+	mode := cfg.ICEMode()
+	if mode != STUNAndTURNMode {
+		return "", nil
+	}
+	var turnEp string
+	if network == NetworkUDP {
+		turnEp = cfg.TURN.UDPEndpoint
+	} else {
+		turnEp = cfg.TURN.TCPEndpoint
+	}
+	var stunEp string
+	if network == NetworkUDP {
+		stunEp = cfg.STUN.UDPEndpoint
+	} else {
+		stunEp = cfg.STUN.TCPEndpoint
+	}
+	addressSame, err := sameAddr(stunEp, turnEp)
+	if err != nil {
+		return "", err
+	}
+	if addressSame { // Either empty endpoint goes to false branch
+		return turnEp, nil
+	} else {
+		return "", nil
+	}
+}
+
+func sameAddr(s1, s2 string) (bool, error) {
+	if s1 == "" || s2 == "" {
+		return false, nil
+	}
+
+	h1, p1, err := net.SplitHostPort(s1)
+	if err != nil {
+		return false, err
+	}
+	h2, p2, err := net.SplitHostPort(s2)
+	if err != nil {
+		return false, err
+	}
+	if p1 != p2 {
+		return false, nil
+	}
+	if isWildcardHost(h1) || isWildcardHost(h2) {
+		return true, nil
+	}
+
+	return hostsCollide(h1, h2)
+}
+
+func hostsCollide(h1, h2 string) (bool, error) {
+	// If both literal IPs, compare directly.
+	if ip1, ip2 := net.ParseIP(h1), net.ParseIP(h2); ip1 != nil && ip2 != nil {
+		return ip1.Equal(ip2), nil
+	}
+	// Otherwise do DNS-aware overlap check.
+	return dnsOverlap(h1, h2)
+}
+
+func dnsOverlap(h1, h2 string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), dnsTimeout)
+	defer cancel()
+
+	ips1, err := net.DefaultResolver.LookupIPAddr(ctx, h1)
+	if err != nil {
+		return false, err
+	}
+	ips2, err := net.DefaultResolver.LookupIPAddr(ctx, h2)
+	if err != nil {
+		return false, err
+	}
+
+	set := make(map[string]struct{}, len(ips1))
+	for _, a := range ips1 {
+		set[a.IP.String()] = struct{}{}
+	}
+	for _, b := range ips2 {
+		if _, ok := set[b.IP.String()]; ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func isWildcardHost(h string) bool {
+	return h == "" || h == "0.0.0.0" || h == "::"
+}

--- a/internal/ice/config.go
+++ b/internal/ice/config.go
@@ -46,15 +46,16 @@ type STUNConfig struct {
 }
 
 type TURNConfig struct {
-	TLS          TLSConfig `mapstructure:"tls"`
+	User         string    `mapstructure:"user"`
 	UDPEndpoint  string    `mapstructure:"udp_endpoint"`
 	TCPEndpoint  string    `mapstructure:"tcp_endpoint"`
 	PublicIP     string    `mapstructure:"public_ip"`
 	Realm        string    `mapstructure:"realm"`
 	Auth         string    `mapstructure:"auth"`
-	User         string    `mapstructure:"user"`
 	Password     string    `mapstructure:"password"`
 	Secret       string    `mapstructure:"secret"`
+	Address      string    `mapstructure:"address"`
+	TLS          TLSConfig `mapstructure:"tls"`
 	PortRangeMin uint16    `mapstructure:"port_range_min"`
 	PortRangeMax uint16    `mapstructure:"port_range_max"`
 	Enabled      bool
@@ -64,6 +65,7 @@ type TLSConfig struct {
 	Endpoint string `mapstructure:"endpoint"`
 	Cert     string `mapstructure:"cert"`
 	Key      string `mapstructure:"key"`
+	Version  uint16 `mapstructure:"version"`
 }
 
 func DefaultICEConfig() ICEConfig {
@@ -79,6 +81,7 @@ func DefaultICEConfig() ICEConfig {
 			TCPEndpoint:  ":3478",
 			PublicIP:     "",
 			Realm:        "ion",
+			Address:      "0.0.0.0",
 			PortRangeMin: DefaultPortRangeMin,
 			PortRangeMax: DefaultPortRangeMax,
 		},

--- a/internal/ice/config_test.go
+++ b/internal/ice/config_test.go
@@ -1,0 +1,278 @@
+package ice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestICEMode(t *testing.T) {
+	cases := []struct {
+		stun, turn bool
+		want       iceServerMode
+	}{
+		{false, false, Disabled},
+		{true, false, STUNOnlyMode},
+		{false, true, TURNOnlyMode},
+		{true, true, STUNAndTURNMode},
+	}
+	for i, tc := range cases {
+		cfg := DefaultICEConfig()
+		cfg.STUN.Enabled = tc.stun
+		cfg.TURN.Enabled = tc.turn
+		require.Equalf(t, tc.want, cfg.ICEMode(), "case %d", i)
+	}
+}
+
+func TestSTUNOnlyEndpoint_UDP(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    string
+		cfg     ICEConfig
+		wantErr bool
+	}{
+		{
+			name: "STUN only returns its UDP endpoint",
+			cfg:  ICEConfig{STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3478"}},
+			want: ":3478",
+		},
+		{
+			name: "TURN only ⇒ empty",
+			cfg:  ICEConfig{TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"}},
+			want: "",
+		},
+		{
+			name: "Both enabled, same UDP endpoint ⇒ empty",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3478"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+			},
+			want: "",
+		},
+		{
+			name: "Both enabled, different UDP endpoints ⇒ return STUN endpoint",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3479"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+			},
+			want: ":3479",
+		},
+		{
+			name: "Empty STUN endpoint ⇒ empty",
+			cfg:  ICEConfig{STUN: STUNConfig{Enabled: true, UDPEndpoint: ""}},
+			want: "",
+		},
+		{
+			name: "IPv6 bracket forms, different ports ⇒ return STUN endpoint",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: "[::1]:3479"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: "[::1]:3478"},
+			},
+			want: "[::1]:3479",
+		},
+		{
+			name: "Hostname vs IP, same port but different hosts ⇒ return empty",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: "localhost:3478"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: "127.0.0.1:3478"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.cfg.STUNOnlyEndpoint(NetworkUDP)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSTUNOnlyEndpoint_TCP(t *testing.T) {
+	cfg := ICEConfig{
+		STUN: STUNConfig{Enabled: true, TCPEndpoint: ":3478"},
+	}
+	got, err := cfg.STUNOnlyEndpoint(NetworkTCP)
+	require.NoError(t, err)
+	require.Equal(t, ":3478", got)
+}
+
+func TestTURNOnlyEndpoint_UDP(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		cfg  ICEConfig
+	}{
+		{
+			name: "TURN only returns its UDP endpoint",
+			cfg:  ICEConfig{TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"}},
+			want: ":3478",
+		},
+		{
+			name: "STUN only ⇒ empty",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3478"},
+			},
+			want: "",
+		},
+		{
+			name: "Both enabled, same UDP endpoint ⇒ empty",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3478"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+			},
+			want: "",
+		},
+		{
+			name: "Both enabled, different UDP endpoints ⇒ return TURN endpoint",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3479"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+			},
+			want: ":3478",
+		},
+		{
+			name: "Empty TURN endpoint ⇒ empty",
+			cfg:  ICEConfig{TURN: TURNConfig{Enabled: true, UDPEndpoint: ""}},
+			want: "",
+		},
+		{
+			name: "IPv6 bracket forms, different hosts same port ⇒ return empty",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: "[::1]:3478"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: "[::]:3478"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.cfg.TURNOnlyEndpoint(NetworkUDP)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestTURNOnlyEndpoint_TCP(t *testing.T) {
+	cfg := ICEConfig{
+		TURN: TURNConfig{Enabled: true, TCPEndpoint: ":3478"},
+	}
+	got, err := cfg.TURNOnlyEndpoint(NetworkTCP)
+	require.NoError(t, err)
+	require.Equal(t, ":3478", got)
+}
+
+func TestTURNSTUNEndpoint_UDP(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		cfg  ICEConfig
+	}{
+		{
+			name: "Both enabled, same endpoint ⇒ shared returned",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3478"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+			},
+			want: ":3478",
+		},
+		{
+			name: "Both enabled, different endpoints ⇒ empty",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3479"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+			},
+			want: "",
+		},
+		{
+			name: "Not both enabled ⇒ empty",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3478"},
+				TURN: TURNConfig{Enabled: false, UDPEndpoint: ":3478"},
+			},
+			want: "",
+		},
+		{
+			name: "IPv6 shared ⇒ shared returned",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: "[::1]:3478"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: "[::1]:3478"},
+			},
+			want: "[::1]:3478",
+		},
+		{
+			name: "Hostname vs IP same port ⇒  shared ⇒ TURN's endpoint",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: "localhost:3478"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: "127.0.0.1:3478"},
+			},
+			want: "127.0.0.1:3478",
+		},
+		{
+			name: "One endpoint empty ⇒ empty",
+			cfg: ICEConfig{
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: ""},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.cfg.TURNSTUNEndpoint(NetworkUDP)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestTURNSTUNEndpoint_TCP(t *testing.T) {
+	cfg := ICEConfig{
+		STUN: STUNConfig{Enabled: true, TCPEndpoint: "[::1]:3478"},
+		TURN: TURNConfig{Enabled: true, TCPEndpoint: "[::1]:3478"},
+	}
+	got, err := cfg.TURNSTUNEndpoint(NetworkTCP)
+	require.NoError(t, err)
+	require.Equal(t, "[::1]:3478", got)
+}
+
+func TestSameAddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     string
+		wantSame bool
+		wantErr  bool
+	}{
+		{"bare port equal", ":3478", ":3478", true, false},
+		{"ipv4 equal", "127.0.0.1:3478", "127.0.0.1:3478", true, false},
+		{"ipv6 equal", "[::1]:3478", "[::1]:3478", true, false},
+		{"different port", "127.0.0.1:3478", "127.0.0.1:3479", false, false},
+		{"different host", "127.0.0.1:3478", "127.0.0.2:3478", false, false},
+		{"hostname vs ip", "localhost:3478", "127.0.0.1:3478", true, false},
+		{"zero vs bare", "0.0.0.0:3478", ":3478", true, false},
+		{"missing port", "127.0.0.1", ":3478", false, true},
+		{"malformed", ";3478", ":3478", false, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sameAddr(tc.a, tc.b)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantSame, got)
+		})
+	}
+}

--- a/internal/ice/config_test.go
+++ b/internal/ice/config_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"testing"
 
+	"github.com/pion/ion/v2/internal/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -322,7 +323,7 @@ func TestICEConfigValidate(t *testing.T) {
 
 				return cfg
 			}(),
-			err: errInvalidHostPort,
+			err: utils.ErrInvalidHostPort,
 		},
 		{
 			name: "STUN enabled but invalid TCP endpoints",
@@ -334,7 +335,7 @@ func TestICEConfigValidate(t *testing.T) {
 
 				return cfg
 			}(),
-			err: errInvalidHostPort,
+			err: utils.ErrInvalidHostPort,
 		},
 		{
 			name: "TURN enabled but invalid UDP endpoints",
@@ -346,7 +347,7 @@ func TestICEConfigValidate(t *testing.T) {
 
 				return cfg
 			}(),
-			err: errInvalidHostPort,
+			err: utils.ErrInvalidHostPort,
 		},
 		{
 			name: "TURN enabled but invalid TCP endpoints",
@@ -358,7 +359,7 @@ func TestICEConfigValidate(t *testing.T) {
 
 				return cfg
 			}(),
-			err: errInvalidHostPort,
+			err: utils.ErrInvalidHostPort,
 		},
 		{
 			name: "TURN invalid TLS endpoints",
@@ -369,7 +370,7 @@ func TestICEConfigValidate(t *testing.T) {
 
 				return cfg
 			}(),
-			err: errInvalidHostPort,
+			err: utils.ErrInvalidHostPort,
 		},
 		{
 			name: "TURN enabled but all endpoints empty",

--- a/internal/ice/config_test.go
+++ b/internal/ice/config_test.go
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2025 The Pion community
+// SPDX-License-Identifier: MIT
 package ice
 
 import (

--- a/internal/ice/config_test.go
+++ b/internal/ice/config_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	realmIon     = "ion"
+	authStatic   = "static"
+	defaultEP    = ":3478"
+	defaultTLSEp = "127.0.0.1:5349"
+)
+
 func TestICEMode(t *testing.T) {
 	cases := []struct {
 		stun, turn bool
@@ -35,19 +42,19 @@ func TestSTUNOnlyEndpoint_UDP(t *testing.T) {
 	}{
 		{
 			name: "STUN only returns its UDP endpoint",
-			cfg:  ICEConfig{STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3478"}},
-			want: ":3478",
+			cfg:  ICEConfig{STUN: STUNConfig{Enabled: true, UDPEndpoint: defaultEP}},
+			want: defaultEP,
 		},
 		{
 			name: "TURN only ⇒ empty",
-			cfg:  ICEConfig{TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"}},
+			cfg:  ICEConfig{TURN: TURNConfig{Enabled: true, UDPEndpoint: defaultEP}},
 			want: "",
 		},
 		{
 			name: "Both enabled, same UDP endpoint ⇒ empty",
 			cfg: ICEConfig{
-				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3478"},
-				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: defaultEP},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: defaultEP},
 			},
 			want: "",
 		},
@@ -55,7 +62,7 @@ func TestSTUNOnlyEndpoint_UDP(t *testing.T) {
 			name: "Both enabled, different UDP endpoints ⇒ return STUN endpoint",
 			cfg: ICEConfig{
 				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3479"},
-				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: defaultEP},
 			},
 			want: ":3479",
 		},
@@ -98,11 +105,11 @@ func TestSTUNOnlyEndpoint_UDP(t *testing.T) {
 
 func TestSTUNOnlyEndpoint_TCP(t *testing.T) {
 	cfg := ICEConfig{
-		STUN: STUNConfig{Enabled: true, TCPEndpoint: ":3478"},
+		STUN: STUNConfig{Enabled: true, TCPEndpoint: defaultEP},
 	}
 	got, err := cfg.STUNOnlyEndpoint(NetworkTCP)
 	require.NoError(t, err)
-	require.Equal(t, ":3478", got)
+	require.Equal(t, defaultEP, got)
 }
 
 func TestTURNOnlyEndpoint_UDP(t *testing.T) {
@@ -113,21 +120,21 @@ func TestTURNOnlyEndpoint_UDP(t *testing.T) {
 	}{
 		{
 			name: "TURN only returns its UDP endpoint",
-			cfg:  ICEConfig{TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"}},
-			want: ":3478",
+			cfg:  ICEConfig{TURN: TURNConfig{Enabled: true, UDPEndpoint: defaultEP}},
+			want: defaultEP,
 		},
 		{
 			name: "STUN only ⇒ empty",
 			cfg: ICEConfig{
-				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3478"},
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: defaultEP},
 			},
 			want: "",
 		},
 		{
 			name: "Both enabled, same UDP endpoint ⇒ empty",
 			cfg: ICEConfig{
-				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3478"},
-				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: defaultEP},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: defaultEP},
 			},
 			want: "",
 		},
@@ -135,9 +142,9 @@ func TestTURNOnlyEndpoint_UDP(t *testing.T) {
 			name: "Both enabled, different UDP endpoints ⇒ return TURN endpoint",
 			cfg: ICEConfig{
 				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3479"},
-				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: defaultEP},
 			},
-			want: ":3478",
+			want: defaultEP,
 		},
 		{
 			name: "Empty TURN endpoint ⇒ empty",
@@ -165,11 +172,11 @@ func TestTURNOnlyEndpoint_UDP(t *testing.T) {
 
 func TestTURNOnlyEndpoint_TCP(t *testing.T) {
 	cfg := ICEConfig{
-		TURN: TURNConfig{Enabled: true, TCPEndpoint: ":3478"},
+		TURN: TURNConfig{Enabled: true, TCPEndpoint: defaultEP},
 	}
 	got, err := cfg.TURNOnlyEndpoint(NetworkTCP)
 	require.NoError(t, err)
-	require.Equal(t, ":3478", got)
+	require.Equal(t, defaultEP, got)
 }
 
 func TestTURNSTUNEndpoint_UDP(t *testing.T) {
@@ -181,24 +188,24 @@ func TestTURNSTUNEndpoint_UDP(t *testing.T) {
 		{
 			name: "Both enabled, same endpoint ⇒ shared returned",
 			cfg: ICEConfig{
-				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3478"},
-				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: defaultEP},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: defaultEP},
 			},
-			want: ":3478",
+			want: defaultEP,
 		},
 		{
 			name: "Both enabled, different endpoints ⇒ empty",
 			cfg: ICEConfig{
 				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3479"},
-				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: defaultEP},
 			},
 			want: "",
 		},
 		{
 			name: "Not both enabled ⇒ empty",
 			cfg: ICEConfig{
-				STUN: STUNConfig{Enabled: true, UDPEndpoint: ":3478"},
-				TURN: TURNConfig{Enabled: false, UDPEndpoint: ":3478"},
+				STUN: STUNConfig{Enabled: true, UDPEndpoint: defaultEP},
+				TURN: TURNConfig{Enabled: false, UDPEndpoint: defaultEP},
 			},
 			want: "",
 		},
@@ -222,7 +229,7 @@ func TestTURNSTUNEndpoint_UDP(t *testing.T) {
 			name: "One endpoint empty ⇒ empty",
 			cfg: ICEConfig{
 				STUN: STUNConfig{Enabled: true, UDPEndpoint: ""},
-				TURN: TURNConfig{Enabled: true, UDPEndpoint: ":3478"},
+				TURN: TURNConfig{Enabled: true, UDPEndpoint: defaultEP},
 			},
 			want: "",
 		},
@@ -254,15 +261,15 @@ func TestSameAddr(t *testing.T) {
 		wantSame bool
 		wantErr  bool
 	}{
-		{"bare port equal", ":3478", ":3478", true, false},
+		{"bare port equal", defaultEP, defaultEP, true, false},
 		{"ipv4 equal", "127.0.0.1:3478", "127.0.0.1:3478", true, false},
 		{"ipv6 equal", "[::1]:3478", "[::1]:3478", true, false},
 		{"different port", "127.0.0.1:3478", "127.0.0.1:3479", false, false},
 		{"different host", "127.0.0.1:3478", "127.0.0.2:3478", false, false},
 		{"hostname vs ip", "localhost:3478", "127.0.0.1:3478", true, false},
-		{"zero vs bare", "0.0.0.0:3478", ":3478", true, false},
-		{"missing port", "127.0.0.1", ":3478", false, true},
-		{"malformed", ";3478", ":3478", false, true},
+		{"zero vs bare", "0.0.0.0:3478", defaultEP, true, false},
+		{"missing port", "127.0.0.1", defaultEP, false, true},
+		{"malformed", ";3478", defaultEP, false, true},
 	}
 
 	for _, tc := range tests {
@@ -275,6 +282,180 @@ func TestSameAddr(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tc.wantSame, got)
+		})
+	}
+}
+
+func TestICEConfigValidate(t *testing.T) {
+	tests := []struct {
+		err  error
+		name string
+		cfg  ICEConfig
+	}{
+		{
+			name: "Disabled OK",
+			cfg:  DefaultICEConfig(),
+			err:  nil,
+		},
+		{
+			name: "STUN enabled but empty endpoints",
+			cfg: func() ICEConfig {
+				cfg := DefaultICEConfig()
+				cfg.STUN.Enabled = true
+				cfg.STUN.UDPEndpoint = ""
+				cfg.STUN.TCPEndpoint = ""
+
+				return cfg
+			}(),
+			err: errEmptySTUNEndpoint,
+		},
+		{
+			name: "TURN enabled but all endpoints empty",
+			cfg: func() ICEConfig {
+				cfg := DefaultICEConfig()
+				cfg.TURN.Enabled = true
+				cfg.TURN.UDPEndpoint = ""
+				cfg.TURN.TCPEndpoint = ""
+				cfg.TURN.TLS.Endpoint = ""
+				cfg.TURN.Realm = realmIon
+				cfg.TURN.Auth = authStatic
+				cfg.TURN.User = "u"
+				cfg.TURN.Password = "p"
+
+				return cfg
+			}(),
+			err: errEmptyTURNEndpoint,
+		},
+		{
+			name: "TURN empty realm",
+			cfg: func() ICEConfig {
+				cfg := DefaultICEConfig()
+				cfg.TURN.Enabled = true
+				cfg.TURN.UDPEndpoint = defaultEP
+				cfg.TURN.Realm = " "
+				cfg.TURN.Auth = authStatic
+				cfg.TURN.User = "u"
+				cfg.TURN.Password = "p"
+
+				return cfg
+			}(),
+			err: errEmptyRealm,
+		},
+		{
+			name: "TURN invalid port range (min=0 max>0)",
+			cfg: func() ICEConfig {
+				cfg := DefaultICEConfig()
+				cfg.TURN.Enabled = true
+				cfg.TURN.UDPEndpoint = defaultEP
+				cfg.TURN.Realm = realmIon
+				cfg.TURN.Auth = authStatic
+				cfg.TURN.User = "u"
+				cfg.TURN.Password = "p"
+				cfg.TURN.PortRangeMin = 0
+				cfg.TURN.PortRangeMax = 60000
+
+				return cfg
+			}(),
+			err: errInvalidPortRange,
+		},
+		{
+			name: "TURN static auth missing user",
+			cfg: func() ICEConfig {
+				cfg := DefaultICEConfig()
+				cfg.TURN.Enabled = true
+				cfg.TURN.UDPEndpoint = defaultEP
+				cfg.TURN.Realm = realmIon
+				cfg.TURN.Auth = authStatic
+				cfg.TURN.User = ""
+				cfg.TURN.Password = "p"
+
+				return cfg
+			}(),
+			err: errEmptyTURNUserPwd,
+		},
+		{
+			name: "TURN long-term missing secret",
+			cfg: func() ICEConfig {
+				cfg := DefaultICEConfig()
+				cfg.TURN.Enabled = true
+				cfg.TURN.UDPEndpoint = defaultEP
+				cfg.TURN.Realm = realmIon
+				cfg.TURN.Auth = "long-term"
+				cfg.TURN.Secret = ""
+
+				return cfg
+			}(),
+			err: errEmptyTURNToken,
+		},
+		{
+			name: "TURN TLS missing cert/key",
+			cfg: func() ICEConfig {
+				cfg := DefaultICEConfig()
+				cfg.TURN.Enabled = true
+				cfg.TURN.UDPEndpoint = defaultEP
+				cfg.TURN.Realm = realmIon
+				cfg.TURN.Auth = authStatic
+				cfg.TURN.User = "u"
+				cfg.TURN.Password = "p"
+				cfg.TURN.TLS.Endpoint = defaultTLSEp // enable TLS mode
+
+				return cfg
+			}(),
+			err: errEmptyTLSCertKey,
+		},
+		{
+			name: "TURN TLS invalid version",
+			cfg: func() ICEConfig {
+				cfg := DefaultICEConfig()
+				cfg.TURN.Enabled = true
+				cfg.TURN.UDPEndpoint = defaultEP
+				cfg.TURN.Realm = realmIon
+				cfg.TURN.Auth = authStatic
+				cfg.TURN.User = "u"
+				cfg.TURN.Password = "p"
+				cfg.TURN.TLS.Endpoint = defaultTLSEp
+				cfg.TURN.TLS.Cert = "/tmp/cert.pem"
+				cfg.TURN.TLS.Key = "/tmp/key.pem"
+				cfg.TURN.TLS.Version = "TLS15"
+
+				return cfg
+			}(),
+			err: errInvalidTLSVersion,
+		},
+		{
+			name: "Valid TURN + STUN + TLS config",
+			cfg: func() ICEConfig {
+				cfg := DefaultICEConfig()
+				cfg.STUN.Enabled = true
+				cfg.STUN.UDPEndpoint = defaultEP
+				cfg.STUN.TCPEndpoint = defaultEP
+				cfg.TURN.Enabled = true
+				cfg.TURN.UDPEndpoint = defaultEP
+				cfg.TURN.TCPEndpoint = defaultEP
+				cfg.TURN.Realm = realmIon
+				cfg.TURN.Auth = authStatic
+				cfg.TURN.User = "u"
+				cfg.TURN.Password = "p"
+				cfg.TURN.TLS.Endpoint = defaultTLSEp
+				cfg.TURN.TLS.Cert = "/tmp/cert.pem"
+				cfg.TURN.TLS.Key = "/tmp/key.pem"
+				cfg.TURN.TLS.Version = "TLS12"
+
+				return cfg
+			}(),
+			err: nil,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.cfg.Validate()
+
+			if testCase.err == nil {
+				require.NoError(t, err, "expected success but got error")
+			} else {
+				require.ErrorIs(t, err, testCase.err, "wrong error returned")
+			}
 		})
 	}
 }

--- a/internal/ice/errors.go
+++ b/internal/ice/errors.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package ice provides ICE, TURN, STUN services for Ion.
+package ice
+
+import "errors"
+
+var errEmptySTUNEndpoint = errors.New("both stun tcp and udp endpoints are empty")
+
+var errEmptyTURNEndpoint = errors.New("turn tcp, udp, and tls endpoints are empty")
+
+var errEmptyRealm = errors.New("realm is empty")
+
+var errEmptyTURNToken = errors.New("turn authentication token is empty")
+
+var errEmptyTURNUserPwd = errors.New("turn authentication user or password is empty")
+
+var errInvalidTURNAuth = errors.New("invalid turn authentication")
+
+var errEmptyTLSCertKey = errors.New("tls cert or key is empty")
+
+var errInvalidTLSVersion = errors.New("invalid TLS version")
+
+var errInvalidPortRange = errors.New("invalid port range")

--- a/internal/ice/errors.go
+++ b/internal/ice/errors.go
@@ -23,3 +23,5 @@ var errEmptyTLSCertKey = errors.New("tls cert or key is empty")
 var errInvalidTLSVersion = errors.New("invalid TLS version")
 
 var errInvalidPortRange = errors.New("invalid port range")
+
+var errInvalidHostPort = errors.New("invalid host port string")

--- a/internal/ice/errors.go
+++ b/internal/ice/errors.go
@@ -23,5 +23,3 @@ var errEmptyTLSCertKey = errors.New("tls cert or key is empty")
 var errInvalidTLSVersion = errors.New("invalid TLS version")
 
 var errInvalidPortRange = errors.New("invalid port range")
-
-var errInvalidHostPort = errors.New("invalid host port string")

--- a/internal/utils/config_validate.go
+++ b/internal/utils/config_validate.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package utils provides utilities.
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+var ErrInvalidHostPort = errors.New("invalid host port string")
+
+func ValidateEndpoint(ep string) error {
+	if ep == "" {
+		return nil
+	}
+	if _, _, err := net.SplitHostPort(ep); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidHostPort, err)
+	}
+
+	return nil
+}

--- a/internal/utils/config_validate_test.go
+++ b/internal/utils/config_validate_test.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateEndpoint(t *testing.T) {
+	err := ValidateEndpoint("")
+	require.NoError(t, err)
+
+	err = ValidateEndpoint(":7000")
+	require.NoError(t, err)
+
+	err = ValidateEndpoint("localhost:7000")
+	require.NoError(t, err)
+
+	err = ValidateEndpoint("127.0.0.1:7000")
+	require.NoError(t, err)
+
+	err = ValidateEndpoint("127.0.0.1;7000")
+	require.ErrorIs(t, err, ErrInvalidHostPort)
+}


### PR DESCRIPTION
#### Description
This is a draft for TURN STUN sidecar for ION. I'm hoping to have some feedbacks before proceeding.
- Implements STUN-only (not TCP support) and STUN-TURN service
- ice/config.go implements logic to parse an endoint to one of (stun|turn|stun-turn). This allows sidecar to run corresponding services.
- Lots of unit tests and integration tests with clients.
#### TODO
- TURN-only service using allocaiton callback.
- Metrics
- Quota
- Dockerfile
- More integration test
#### Reference issue
Fixes #20 #21 
